### PR TITLE
Add Q-Bert laser game

### DIFF
--- a/.stackbit/models/QbertGameSection.ts
+++ b/.stackbit/models/QbertGameSection.ts
@@ -1,0 +1,40 @@
+import { Model } from '@stackbit/types';
+import { colorFields, settingFields, settingFieldsGroup, styleFieldsGroup } from './section-common-fields';
+
+export const QbertGameSectionModel: Model = {
+    type: 'object',
+    name: 'QbertGameSection',
+    label: 'Q-Bert Game',
+    labelField: 'title',
+    thumbnail: 'https://assets.stackbit.com/components/models/thumbnails/default.png',
+    groups: ['SectionModels'],
+    fieldGroups: [...styleFieldsGroup, ...settingFieldsGroup],
+    fields: [
+        {
+            type: 'string',
+            name: 'title',
+            description: 'The value of the field is used for presentation purposes in Stackbit',
+            default: 'Q-Bert Game'
+        },
+        ...colorFields,
+        ...settingFields,
+        {
+            type: 'style',
+            name: 'styles',
+            styles: {
+                self: {
+                    height: ['auto', 'screen'],
+                    width: ['narrow', 'wide', 'full'],
+                    padding: ['tw0:96']
+                }
+            },
+            default: {
+                self: {
+                    height: 'auto',
+                    width: 'narrow',
+                    padding: ['pt-12', 'pb-12', 'pl-4', 'pr-4']
+                }
+            }
+        }
+    ]
+};

--- a/.stackbit/models/index.ts
+++ b/.stackbit/models/index.ts
@@ -41,6 +41,7 @@ import { TextFormControlModel } from './TextFormControl';
 import { TextSectionModel } from './TextSection';
 import { ThemeStyleModel } from './ThemeStyle';
 import { VideoBlockModel } from './VideoBlock';
+import { QbertGameSectionModel } from './QbertGameSection';
 
 export const allModels = [
     BackgroundImageModel,
@@ -84,6 +85,7 @@ export const allModels = [
     TextareaFormControlModel,
     TextFormControlModel,
     TextSectionModel,
+    QbertGameSectionModel,
     ThemeStyleModel,
     VideoBlockModel
 ];

--- a/.stackbit/presets/qbert-game-section.json
+++ b/.stackbit/presets/qbert-game-section.json
@@ -1,0 +1,19 @@
+{
+    "model": "QbertGameSection",
+    "presets": [
+        {
+            "label": "Default game section",
+            "thumbnail": "images/text-transparent-center.png",
+            "data": {
+                "colors": "colors-f",
+                "styles": {
+                    "self": {
+                        "height": "auto",
+                        "width": "narrow",
+                        "padding": ["pt-12", "pb-12", "pl-4", "pr-4"]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The codebase showcases **how to apply annotations at scale**, meaning: how to ma
 
 **⚡ Demo:** [auto-annotated-portfolio.netlify.app](https://auto-annotated-portfolio.netlify.app)
 
+## Q-Bert Laser Game
+
+This site now includes a small Q-Bert inspired game with a new laser mechanic. Visit `/qbert` after starting the dev server to try it out.
+
 ## Deploying to Netlify
 
 If you click "Deploy to Netlify" button, it will create a new repo for you that looks exactly like this one, and sets that repo up immediately for deployment on Netlify.

--- a/content/pages/qbert.md
+++ b/content/pages/qbert.md
@@ -1,0 +1,18 @@
+---
+type: PageLayout
+title: Q-Bert Laser
+colors: colors-a
+sections:
+  - type: QbertGameSection
+    elementId: qbert-game
+    colors: colors-f
+    styles:
+      self:
+        height: auto
+        width: narrow
+        padding:
+          - pt-12
+          - pb-12
+          - pl-4
+          - pr-4
+---

--- a/src/components/components-registry.tsx
+++ b/src/components/components-registry.tsx
@@ -69,6 +69,7 @@ const components = {
     TextareaFormControl: dynamic(() => import('./molecules/FormBlock/TextareaFormControl')),
     TextFormControl: dynamic(() => import('./molecules/FormBlock/TextFormControl')),
     TextSection: dynamic(() => import('./sections/TextSection')),
+    QbertGameSection: dynamic(() => import('./sections/QbertGameSection')),
     VideoBlock: dynamic(() => import('./molecules/VideoBlock')),
     PageLayout: dynamic(() => import('./layouts/PageLayout')),
     PostLayout: dynamic(() => import('./layouts/PostLayout')),

--- a/src/components/sections/QbertGameSection/index.tsx
+++ b/src/components/sections/QbertGameSection/index.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useRef } from 'react';
+import Section from '../Section';
+
+export default function QbertGameSection(props) {
+    const { elementId, colors, styles = {} } = props;
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+
+        const gridSize = 5;
+        const tile = 60;
+        const qbert = { x: 0, y: gridSize - 1 };
+        const lasers: { x: number; y: number }[] = [];
+        let animationFrame: number;
+
+        function drawGrid() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            for (let row = 0; row < gridSize; row++) {
+                for (let col = 0; col <= row; col++) {
+                    const x = (gridSize - row - 1 + col) * tile;
+                    const y = row * tile;
+                    ctx.fillStyle = '#ddd';
+                    ctx.fillRect(x, y, tile, tile);
+                    ctx.strokeStyle = '#888';
+                    ctx.strokeRect(x, y, tile, tile);
+                }
+            }
+        }
+
+        function drawQbert() {
+            const x = (gridSize - qbert.y - 1 + qbert.x) * tile + tile / 2;
+            const y = qbert.y * tile + tile / 2;
+            ctx.fillStyle = 'orange';
+            ctx.beginPath();
+            ctx.arc(x, y, tile / 2 - 4, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        function drawLasers() {
+            ctx.fillStyle = 'red';
+            lasers.forEach((l) => {
+                ctx.fillRect(l.x, l.y, 4, 20);
+            });
+        }
+
+        function render() {
+            drawGrid();
+            drawQbert();
+            drawLasers();
+        }
+
+        function update() {
+            lasers.forEach((l) => (l.y -= 6));
+            for (let i = lasers.length - 1; i >= 0; i--) {
+                if (lasers[i].y < 0) lasers.splice(i, 1);
+            }
+        }
+
+        function loop() {
+            update();
+            render();
+            animationFrame = requestAnimationFrame(loop);
+        }
+        loop();
+
+        function handleKey(e: KeyboardEvent) {
+            if (e.type === 'keydown') {
+                if (e.code === 'ArrowUp' && qbert.y > 0) {
+                    qbert.y -= 1;
+                    if (qbert.x > qbert.y) qbert.x = qbert.y;
+                }
+                if (e.code === 'ArrowDown' && qbert.y < gridSize - 1) {
+                    qbert.y += 1;
+                }
+                if (e.code === 'ArrowLeft' && qbert.x > 0) {
+                    qbert.x -= 1;
+                }
+                if (e.code === 'ArrowRight' && qbert.x < qbert.y) {
+                    qbert.x += 1;
+                }
+                if (e.code === 'Space') {
+                    lasers.push({
+                        x:
+                            (gridSize - qbert.y - 1 + qbert.x) * tile +
+                            tile / 2 -
+                            2,
+                        y: qbert.y * tile,
+                    });
+                }
+            }
+        }
+
+        window.addEventListener('keydown', handleKey);
+        return () => {
+            window.removeEventListener('keydown', handleKey);
+            cancelAnimationFrame(animationFrame);
+        };
+    }, []);
+
+    return (
+        <Section elementId={elementId} colors={colors} styles={styles.self}>
+            <canvas ref={canvasRef} width={360} height={360} className="border" />
+        </Section>
+    );
+}

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -20,7 +20,8 @@ export type SectionModels =
     | RecentPostsSection
     | RecentProjectsSection
     | TestimonialsSection
-    | TextSection;
+    | TextSection
+    | QbertGameSection;
 
 export type ContentObject =
     | BackgroundImage
@@ -64,6 +65,7 @@ export type ContentObject =
     | TextareaFormControl
     | TextFormControl
     | TextSection
+    | QbertGameSection
     | ThemeStyle
     | VideoBlock;
 
@@ -109,6 +111,7 @@ export type ContentObjectType =
     | 'TextareaFormControl'
     | 'TextFormControl'
     | 'TextSection'
+    | 'QbertGameSection'
     | 'ThemeStyle'
     | 'VideoBlock';
 
@@ -697,4 +700,11 @@ export type VideoBlock = BaseContentObject & {
     muted?: boolean;
     controls?: boolean;
     aspectRatio?: '4:3' | '16:9';
+};
+
+export type QbertGameSection = BaseContentObject & {
+    type: 'QbertGameSection';
+    elementId?: string;
+    colors?: 'colors-a' | 'colors-b' | 'colors-c' | 'colors-d' | 'colors-e' | 'colors-f';
+    styles?: any;
 };


### PR DESCRIPTION
## Summary
- create QbertGameSection component and add dynamic mapping
- register QbertGameSection model in Stackbit config
- extend generated types for QbertGameSection
- add new presets and content page for the game
- document new `/qbert` route in README

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_682cc4951c08833085ebd5810f8ad7c1