### PR TITLE
Format hero titles with line breaks

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -14,9 +14,10 @@ sections:
     elementId: ''
     colors: colors-f
     backgroundSize: full
-    title: >-
-      Construction Project Manager | Project Superintendent | Project
-      Controls Team Leader
+    title: |-
+      Construction Project Manager
+      Project Superintendent
+      Project Controls Team Leader
     subtitle: >-
       I bring four decades of experience delivering billion-dollar capital and
       industrial projects, guiding teams from concept through mechanical

--- a/src/components/sections/HeroSection/index.tsx
+++ b/src/components/sections/HeroSection/index.tsx
@@ -23,7 +23,7 @@ export default function Component(props: HeroSection) {
                 <div className={classNames('flex-1 w-full', mapStyles({ textAlign: sectionAlign }))}>
                     {title && (
                         <AnnotatedField path=".title">
-                            <h1 className="text-5xl sm:text-6xl">{title}</h1>
+                            <h1 className="text-5xl sm:text-6xl whitespace-pre-line">{title}</h1>
                         </AnnotatedField>
                     )}
                     {subtitle && (


### PR DESCRIPTION
## Summary
- Render each professional title on its own line in the homepage hero
- Preserve line breaks in hero title rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd4e1298833090e12da0dec0a87f