### PR TITLE
Handle missing theme styles safely

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -7,7 +7,7 @@ export default function MyApp({ Component, pageProps }) {
     const { theme } = global || {};
     const [isMounted, setIsMounted] = useState(false);
 
-    const cssVars = generateGlobalCssVariables(theme);
+    const cssVars = theme ? generateGlobalCssVariables(theme) : '';
 
     useEffect(() => {
         setIsMounted(true);

--- a/src/utils/theme-style-utils.ts
+++ b/src/utils/theme-style-utils.ts
@@ -1,6 +1,10 @@
 import { ThemeStyle } from '@/types';
 
 export function generateGlobalCssVariables(styles: ThemeStyle): string {
+    if (!styles) {
+        return '';
+    }
+
     let cssVars = '';
 
     function processObject(obj, prefix = '--theme-') {


### PR DESCRIPTION
## Summary
- add a guard in `generateGlobalCssVariables` so it returns early when no styles are provided
- only call `generateGlobalCssVariables` in `_app` when a theme exists to avoid accessing undefined values

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ca98c99a0083308769014149d330f9