### PR TITLE
⚡ Optimize sorting with memoization and Schwartzian transform

### DIFF
--- a/src/utils/static-props-resolvers.ts
+++ b/src/utils/static-props-resolvers.ts
@@ -88,16 +88,35 @@ const PropsResolvers: Partial<Record<ContentObjectType, ResolverFunction>> = {
     }
 };
 
+const postsCache = new WeakMap<ContentObject[], PostLayout[]>();
+const projectsCache = new WeakMap<ContentObject[], ProjectLayout[]>();
+
 function getAllPostsSorted(objects: ContentObject[]) {
+    if (postsCache.has(objects)) {
+        return postsCache.get(objects)!;
+    }
     const all = objects.filter((object) => object.__metadata?.modelName === 'PostLayout') as PostLayout[];
-    const sorted = all.sort((postA, postB) => new Date(postB.date).getTime() - new Date(postA.date).getTime());
+    const mapped = all.map((post) => ({
+        post,
+        time: new Date(post.date).getTime()
+    }));
+    mapped.sort((a, b) => b.time - a.time);
+    const sorted = mapped.map((item) => item.post);
+    postsCache.set(objects, sorted);
     return sorted;
 }
 
 function getAllProjectsSorted(objects: ContentObject[]) {
+    if (projectsCache.has(objects)) {
+        return projectsCache.get(objects)!;
+    }
     const all = objects.filter((object) => object.__metadata?.modelName === 'ProjectLayout') as ProjectLayout[];
-    const sorted = all.sort(
-        (projectA, projectB) => new Date(projectB.date).getTime() - new Date(projectA.date).getTime()
-    );
+    const mapped = all.map((project) => ({
+        project,
+        time: new Date(project.date).getTime()
+    }));
+    mapped.sort((a, b) => b.time - a.time);
+    const sorted = mapped.map((item) => item.project);
+    projectsCache.set(objects, sorted);
     return sorted;
 }


### PR DESCRIPTION
I have optimized the `getAllPostsSorted` and `getAllProjectsSorted` functions in `src/utils/static-props-resolvers.ts` to improve performance during the site's build process.

The optimization includes:
1.  **Memoization**: Using `WeakMap` to cache the results of the sorting operation based on the input `objects` array. This ensures that subsequent calls with the same data set are $O(1)$.
2.  **Schwartzian Transform**: Pre-calculating the timestamps from the date strings before sorting. This reduces the number of expensive `new Date()` calls from $O(N \log N)$ to $O(N)$.

I verified the performance gain and correctness with a standalone benchmark script, as the environment had restrictions on running the full Next.js build. The benchmark showed a significant speedup for multiple calls.

---
*PR created automatically by Jules for task [10227520954939962712](https://jules.google.com/task/10227520954939962712) started by @roblem28*