### PR TITLE
⚡ [performance improvement] Optimize repeated sorting and date parsing

### DIFF
--- a/src/utils/static-props-resolvers.ts
+++ b/src/utils/static-props-resolvers.ts
@@ -88,16 +88,30 @@ const PropsResolvers: Partial<Record<ContentObjectType, ResolverFunction>> = {
     }
 };
 
+const postsCache = new WeakMap<ContentObject[], PostLayout[]>();
 function getAllPostsSorted(objects: ContentObject[]) {
+    if (postsCache.has(objects)) {
+        return postsCache.get(objects)!;
+    }
     const all = objects.filter((object) => object.__metadata?.modelName === 'PostLayout') as PostLayout[];
-    const sorted = all.sort((postA, postB) => new Date(postB.date).getTime() - new Date(postA.date).getTime());
+    const sorted = all
+        .map((post) => ({ post, timestamp: new Date(post.date).getTime() }))
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .map((item) => item.post);
+    postsCache.set(objects, sorted);
     return sorted;
 }
 
+const projectsCache = new WeakMap<ContentObject[], ProjectLayout[]>();
 function getAllProjectsSorted(objects: ContentObject[]) {
+    if (projectsCache.has(objects)) {
+        return projectsCache.get(objects)!;
+    }
     const all = objects.filter((object) => object.__metadata?.modelName === 'ProjectLayout') as ProjectLayout[];
-    const sorted = all.sort(
-        (projectA, projectB) => new Date(projectB.date).getTime() - new Date(projectA.date).getTime()
-    );
+    const sorted = all
+        .map((project) => ({ project, timestamp: new Date(project.date).getTime() }))
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .map((item) => item.project);
+    projectsCache.set(objects, sorted);
     return sorted;
 }


### PR DESCRIPTION
This PR optimizes the `getAllPostsSorted` and `getAllProjectsSorted` functions in `src/utils/static-props-resolvers.ts`.

💡 **What:** 
- Implemented a Schwartzian transform to avoid repeated `new Date()` calls during sorting.
- Added memoization using a `WeakMap` to cache the sorted arrays based on the input `objects` array.

🎯 **Why:** 
- Sorting an array multiple times with expensive operations in the comparator (like date parsing) is inefficient.
- In this codebase, these functions were potentially called multiple times during the resolution of props for a single page, leading to redundant computations.

📊 **Measured Improvement:** 
- Although a live benchmark was not possible due to environment restrictions (missing `node_modules`), the optimization is theoretically sound:
    - Date parsing complexity reduced from O(N log N) to O(N).
    - Redundant filtering and sorting reduced to O(1) for repeated calls with the same input reference.
- The use of `WeakMap` ensures memory efficiency by allowing garbage collection of the input arrays.

---
*PR created automatically by Jules for task [17777688238872552314](https://jules.google.com/task/17777688238872552314) started by @roblem28*