### PR TITLE
⚡ Optimize content loading with asynchronous I/O

### DIFF
--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -33,14 +33,14 @@ const Page: React.FC<PageComponentProps> = (props) => {
     );
 };
 
-export function getStaticPaths() {
-    const allData = allContent();
+export async function getStaticPaths() {
+    const allData = await allContent();
     const paths = allData.map((obj) => obj.__metadata.urlPath).filter(Boolean);
     return { paths, fallback: false };
 }
 
-export function getStaticProps({ params }) {
-    const allData = allContent();
+export async function getStaticProps({ params }) {
+    const allData = await allContent();
     const urlPath = '/' + (params.slug || []).join('/');
     const props = resolveStaticProps(urlPath, allData);
     return { props };

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -29,8 +29,8 @@ function contentFilesInPath(dir: string) {
     return glob.sync(globPattern);
 }
 
-function readContent(file: string): types.ContentObject {
-    const rawContent = fs.readFileSync(file, 'utf8');
+async function readContent(file: string): Promise<types.ContentObject> {
+    const rawContent = await fs.promises.readFile(file, 'utf8');
     let content = null;
     switch (path.extname(file).substring(1)) {
         case 'md':
@@ -102,8 +102,8 @@ function contentUrl(obj: types.ContentObject) {
     return url;
 }
 
-export function allContent(): types.ContentObject[] {
-    let objects = contentFilesInPath(contentBaseDir).map((file) => readContent(file));
+export async function allContent(): Promise<types.ContentObject[]> {
+    let objects = await Promise.all(contentFilesInPath(contentBaseDir).map((file) => readContent(file)));
 
     allPages(objects).forEach((obj) => {
         obj.__metadata.urlPath = contentUrl(obj);


### PR DESCRIPTION
💡 **What:** The optimization implemented is the transition from synchronous to asynchronous I/O when reading content files. Specifically, `fs.readFileSync` has been replaced with `fs.promises.readFile`, and `Promise.all` is now used to read multiple files in parallel.

🎯 **Why:** Synchronous I/O operations block the main thread, which is especially detrimental during the Next.js build process when many files need to be processed. By switching to asynchronous I/O and using `Promise.all`, we can perform these I/O operations concurrently, leading to faster build times.

📊 **Measured Improvement:** Due to environment restrictions (missing dependencies and no internet access to install them), I was unable to run a live benchmark to quantify the speedup. However, replacing sequential synchronous reads with parallel asynchronous reads is a well-established optimization for I/O-bound tasks that should result in a measurable performance boost as the number of content files grows.

---
*PR created automatically by Jules for task [5609776688117821504](https://jules.google.com/task/5609776688117821504) started by @roblem28*