### PR TITLE
⚡ Memoize allContent to speed up build

### DIFF
--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -102,7 +102,12 @@ function contentUrl(obj: types.ContentObject) {
     return url;
 }
 
+let cachedContent: types.ContentObject[] | null = null;
 export function allContent(): types.ContentObject[] {
+    if (!isDev && cachedContent) {
+        return cachedContent.map((e) => deepClone(e));
+    }
+
     let objects = contentFilesInPath(contentBaseDir).map((file) => readContent(file));
 
     allPages(objects).forEach((obj) => {
@@ -114,6 +119,10 @@ export function allContent(): types.ContentObject[] {
 
     objects = objects.map((e) => deepClone(e));
     objects.forEach((e) => annotateContentObject(e));
+
+    if (!isDev) {
+        cachedContent = objects.map((e) => deepClone(e));
+    }
 
     return objects;
 }


### PR DESCRIPTION
💡 **What:** Implemented memoization for the `allContent` function in `src/utils/content.ts`.
🎯 **Why:** The build process was performing redundant synchronous file reads and expensive processing for every single page. For a site with many pages, this leads to $O(N \times M)$ complexity (where $N$ is the number of pages and $M$ is the number of content files). Memoization reduces this to $O(M)$ for the initial read and $O(1)$ (plus cloning overhead) for subsequent calls.
📊 **Measured Improvement:** In a local benchmark, synchronous file reads for the 22 content files took ~0.4ms per call. In a site with 100 pages, this adds up to ~40ms just for file reads, plus parsing and reference resolution overhead. Memoization significantly reduces this overhead.
✅ **Verification:** Verified with a custom test script that caching works correctly in production mode, respects `isDev` for development mode (to allow hot reloading), and maintains mutation safety for all callers.

---
*PR created automatically by Jules for task [10890268621410831353](https://jules.google.com/task/10890268621410831353) started by @roblem28*