### PR TITLE
Add FEC campaign-finance explorer to /projects/

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ Here are a few suggestions on what to do next if you're new to Netlify Visual Ed
 - Learn [how Netlify Visual Editor works](https://docs.netlify.com/visual-editor/overview/)
 - Check [Netlify visual editor reference documentation](https://visual-editor-reference.netlify.com/)
 
+## Projects: FEC Campaign Finance Explorer
+
+`/projects/fec` is a self-contained explorer for FEC campaign-finance data
+(OpenFEC API), following the same pattern as the Federal Award Explorer
+(`/projects/spending`): a static app in `public/projects/fec/` embedded via an
+iframe, backed by an in-repo API route.
+
+- **Proxy:** `src/pages/api/fec.js` — a generic, allow-listed proxy that injects
+  the server-side `FEC_API_KEY`, forwards to `https://api.open.fec.gov/v1`, and
+  handles 429 rate limits with backoff. The key is **never** exposed to the browser.
+- **Tabs:** Contributions (Schedule A), Committees, Candidates, Independent
+  Expenditures (Schedule E), Filings, and a Cross-Reference tab that joins FEC
+  contributions to USAspending federal contract awards with a 0–100 match
+  confidence score (name-only matches are flagged `REVIEW`).
+- **Health check:** `GET /api/fec?health=1` hits `/candidates/search?q=cramer`
+  to confirm the key works end to end.
+
+### Setting `FEC_API_KEY`
+
+Get a key at [api.data.gov/signup](https://api.data.gov/signup/).
+
+- **Local:** add `FEC_API_KEY=your_key_here` to `.env.local` (gitignored — never commit it).
+- **Production (Netlify):** add it as an environment variable, then redeploy:
+  ```txt
+  netlify env:set FEC_API_KEY your_key_here
+  ```
+  or in the UI: **Site settings → Environment variables → Add a variable**
+  (key `FEC_API_KEY`, scope: all / Functions). Do not commit the key.
+
+### Compliance & use
+
+FEC data is provided for **research and transparency purposes only**. Under
+52 U.S.C. § 30111(a)(4), contributor information (including names and addresses)
+may **not** be used for commercial purposes or to solicit contributions or
+donations. This is not an official government product.
+
 ## Support
 
 If you get stuck along the way, get help in our [support forums](https://answers.netlify.com/).

--- a/content/pages/projects/index.md
+++ b/content/pages/projects/index.md
@@ -147,6 +147,19 @@ sections:
         styles:
           self:
             textAlign: left
+      - type: FeaturedItem
+        title: FEC Campaign Finance Explorer
+        text: >-
+          An OpenFEC explorer for contributions, committees, candidates,
+          independent expenditures, and filings — plus a contributor-to-federal-
+          contract cross-reference with match confidence scoring.
+        actions:
+          - type: Link
+            label: Learn more
+            url: /projects/fec
+        styles:
+          self:
+            textAlign: left
     actions:
       - type: Link
         label: View all Tech Projects

--- a/public/projects/fec/app.js
+++ b/public/projects/fec/app.js
@@ -1,0 +1,567 @@
+/* FEC Campaign Finance Explorer — vanilla JS.
+ *
+ * Six tabs, all driven by ONE backend proxy: the in-repo Next.js API route
+ * /api/fec, which injects the server-side FEC_API_KEY and forwards to the
+ * OpenFEC API. The browser never sees the key.
+ *
+ *   Contributions  → /schedules/schedule_a   (keyset pagination)
+ *   Committees     → /committees             (offset pagination)
+ *   Candidates     → /candidates/search      (offset pagination)
+ *   Expenditures   → /schedules/schedule_e   (keyset pagination)
+ *   Filings        → /filings                (offset pagination)
+ *   Cross-Reference→ /schedules/schedule_a  +  /api/usaspending (contract join)
+ *
+ * Each results table supports client-side column sort and CSV + Excel export
+ * (SheetJS, loaded via CDN — same as the spending dashboard).
+ */
+
+const FEC_PROXY = '/api/fec';
+const USA_PROXY = '/api/usaspending'; // reuse the existing in-repo USAspending route
+const PER_PAGE = 30;
+
+// ---- generic helpers -----------------------------------------------------
+function fmtUSD(n) {
+  if (n == null || n === '' || isNaN(n)) return '—';
+  return Number(n).toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+}
+function fmtDate(s) {
+  if (!s) return '—';
+  return String(s).slice(0, 10);
+}
+function escapeHtml(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+function val(id) {
+  const el = document.getElementById(id);
+  return el ? el.value.trim() : '';
+}
+function csvList(s) {
+  return String(s || '').split(',').map((x) => x.trim()).filter(Boolean);
+}
+function fecCommitteeLink(id, label) {
+  if (!id) return escapeHtml(label) || '—';
+  return `<a href="https://www.fec.gov/data/committee/${encodeURIComponent(id)}/" target="_blank" rel="noopener">${escapeHtml(label || id)}</a>`;
+}
+function fecCandidateLink(id, label) {
+  if (!id) return escapeHtml(label) || '—';
+  return `<a href="https://www.fec.gov/data/candidate/${encodeURIComponent(id)}/" target="_blank" rel="noopener">${escapeHtml(label || id)}</a>`;
+}
+
+// ---- proxy calls ---------------------------------------------------------
+async function fecGet(endpoint, params) {
+  const qs = new URLSearchParams({ endpoint });
+  for (const [k, v] of Object.entries(params || {})) {
+    if (v == null || v === '') continue;
+    if (Array.isArray(v)) v.forEach((item) => qs.append(k, item));
+    else qs.append(k, v);
+  }
+  const res = await fetch(`${FEC_PROXY}?${qs.toString()}`);
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = data.detail || data.error || `HTTP ${res.status}`;
+    throw new Error(typeof detail === 'string' ? detail : JSON.stringify(detail));
+  }
+  return data;
+}
+
+async function usaPost(path, body) {
+  const res = await fetch(`${USA_PROXY}?path=${encodeURIComponent(path)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.detail || data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+// ---- per-tab configuration ----------------------------------------------
+// Each tab: endpoint, pagination type, param builder, row mapper, and a `fmt`
+// map of column-key → cell renderer (defaults to escaped text).
+const TABS = {
+  contributions: {
+    endpoint: '/schedules/schedule_a',
+    pagination: 'keyset',
+    sort: '-contribution_receipt_date',
+    buildParams() {
+      const p = { per_page: PER_PAGE, sort: '-contribution_receipt_date' };
+      if (val('c_name')) p.contributor_name = val('c_name');
+      if (val('c_employer')) p.contributor_employer = val('c_employer');
+      if (val('c_occupation')) p.contributor_occupation = val('c_occupation');
+      if (val('c_state')) p.contributor_state = val('c_state').toUpperCase();
+      if (val('c_committee')) p.committee_id = val('c_committee').toUpperCase();
+      if (val('c_min_date')) p.min_date = val('c_min_date');
+      if (val('c_max_date')) p.max_date = val('c_max_date');
+      if (val('c_min_amt')) p.min_amount = val('c_min_amt');
+      if (val('c_max_amt')) p.max_amount = val('c_max_amt');
+      return p;
+    },
+    mapRow: (r) => r,
+    fmt: {
+      contribution_receipt_amount: (r) => fmtUSD(r.contribution_receipt_amount),
+      contribution_receipt_date: (r) => fmtDate(r.contribution_receipt_date),
+      committee_name: (r) => fecCommitteeLink(r.committee_id, r.committee_name)
+    }
+  },
+
+  committees: {
+    endpoint: '/committees',
+    pagination: 'offset',
+    buildParams() {
+      const p = { per_page: PER_PAGE };
+      if (val('cm_q')) p.q = val('cm_q');
+      if (val('cm_state')) p.state = val('cm_state').toUpperCase();
+      if (val('cm_type')) p.committee_type = val('cm_type');
+      return p;
+    },
+    mapRow: (r) => r,
+    fmt: {
+      name: (r) => fecCommitteeLink(r.committee_id, r.name)
+    }
+  },
+
+  candidates: {
+    endpoint: '/candidates/search',
+    pagination: 'offset',
+    buildParams() {
+      const p = { per_page: PER_PAGE };
+      if (val('cd_q')) p.q = val('cd_q');
+      if (val('cd_state')) p.state = val('cd_state').toUpperCase();
+      if (val('cd_office')) p.office = val('cd_office');
+      if (val('cd_cycle')) p.cycle = val('cd_cycle');
+      return p;
+    },
+    mapRow: (r) => r,
+    fmt: {
+      name: (r) => fecCandidateLink(r.candidate_id, r.name),
+      candidate_id: (r) => {
+        const profile = fecCandidateLink(r.candidate_id, 'FEC profile + totals');
+        const pcs = (r.principal_committees || [])
+          .map((c) => fecCommitteeLink(c.committee_id, c.name || c.committee_id))
+          .join(', ');
+        return pcs ? `${profile}<br>${pcs}` : profile;
+      }
+    }
+  },
+
+  expenditures: {
+    endpoint: '/schedules/schedule_e',
+    pagination: 'keyset',
+    sort: '-expenditure_date',
+    buildParams() {
+      const p = { per_page: PER_PAGE, sort: '-expenditure_date' };
+      if (val('e_candidate')) p.candidate_name = val('e_candidate');
+      if (val('e_committee')) p.committee_id = val('e_committee').toUpperCase();
+      if (val('e_support')) p.support_oppose_indicator = val('e_support');
+      if (val('e_min_date')) p.min_date = val('e_min_date');
+      if (val('e_max_date')) p.max_date = val('e_max_date');
+      return p;
+    },
+    mapRow: (r) => r,
+    fmt: {
+      support_oppose_indicator: (r) => (r.support_oppose_indicator === 'S' ? 'Support' : r.support_oppose_indicator === 'O' ? 'Oppose' : '—'),
+      expenditure_amount: (r) => fmtUSD(r.expenditure_amount),
+      expenditure_date: (r) => fmtDate(r.expenditure_date),
+      committee_name: (r) => fecCommitteeLink(r.committee_id, r.committee_name)
+    }
+  },
+
+  filings: {
+    endpoint: '/filings',
+    pagination: 'offset',
+    sort: '-receipt_date',
+    buildParams() {
+      const p = { per_page: PER_PAGE, sort: '-receipt_date' };
+      if (val('f_committee')) p.committee_id = val('f_committee').toUpperCase();
+      if (val('f_candidate')) p.candidate_id = val('f_candidate').toUpperCase();
+      if (val('f_cycle')) p.cycle = val('f_cycle');
+      return p;
+    },
+    mapRow: (r) => r,
+    fmt: {
+      committee_name: (r) => fecCommitteeLink(r.committee_id, r.committee_name),
+      coverage_end_date: (r) => fmtDate(r.coverage_end_date),
+      receipt_date: (r) => fmtDate(r.receipt_date),
+      total_receipts: (r) => fmtUSD(r.total_receipts),
+      pdf_url: (r) => (r.pdf_url ? `<a href="${escapeHtml(r.pdf_url)}" target="_blank" rel="noopener">PDF</a>` : '—')
+    }
+  }
+};
+
+// ---- per-tab runtime state ----------------------------------------------
+const state = {};
+function initState(name) {
+  state[name] = {
+    rows: [],
+    page: 1,
+    cursorStack: [{}], // keyset cursors; cursorStack[i] fetches page i+1
+    hasNext: false,
+    totalCount: null,
+    sort: { key: null, dir: 'desc' },
+    lastParams: null
+  };
+}
+Object.keys(TABS).forEach(initState);
+
+// ---- table rendering (generic, driven by <thead> data-key) --------------
+function columnsFor(name) {
+  const table = document.querySelector(`table[data-table="${name}"]`);
+  return [...table.querySelectorAll('thead th')].map((th) => ({
+    key: th.dataset.key,
+    label: th.textContent.replace(/[▲▼]/g, '').trim(),
+    num: th.classList.contains('num'),
+    nosort: th.classList.contains('nosort')
+  }));
+}
+
+function setStatus(name, msg, cls) {
+  const el = document.querySelector(`[data-status="${name}"]`);
+  el.textContent = msg || '';
+  el.className = 'status' + (cls ? ' ' + cls : '');
+}
+
+function renderTable(name) {
+  const cfg = TABS[name] || {};
+  const st = state[name];
+  const table = document.querySelector(`table[data-table="${name}"]`);
+  const tbody = table.querySelector('tbody');
+  const empty = table.parentElement.querySelector('.empty');
+  const cols = columnsFor(name);
+
+  const rows = sortedRows(name);
+  if (!rows.length) {
+    tbody.innerHTML = '';
+    empty.hidden = false;
+  } else {
+    empty.hidden = true;
+    tbody.innerHTML = rows
+      .map((r) => {
+        const tds = cols
+          .map((c) => {
+            const fmt = cfg.fmt && cfg.fmt[c.key];
+            const cell = fmt ? fmt(r) : escapeHtml(r[c.key] != null && r[c.key] !== '' ? r[c.key] : '—');
+            return `<td class="${c.num ? 'num' : ''}">${cell}</td>`;
+          })
+          .join('');
+        return `<tr>${tds}</tr>`;
+      })
+      .join('');
+  }
+  updateHeaderArrows(name);
+  updatePager(name);
+}
+
+function sortedRows(name) {
+  const st = state[name];
+  if (!st.sort.key) return st.rows;
+  const { key, dir } = st.sort;
+  const mult = dir === 'asc' ? 1 : -1;
+  return [...st.rows].sort((a, b) => {
+    let av = a[key];
+    let bv = b[key];
+    const an = typeof av === 'number';
+    const bn = typeof bv === 'number';
+    if (an || bn) return (((av == null ? -Infinity : av)) - ((bv == null ? -Infinity : bv))) * mult;
+    return String(av == null ? '' : av).localeCompare(String(bv == null ? '' : bv)) * mult;
+  });
+}
+
+function updateHeaderArrows(name) {
+  const st = state[name];
+  document.querySelectorAll(`table[data-table="${name}"] thead th`).forEach((th) => {
+    const arrow = th.querySelector('.arrow');
+    if (arrow) arrow.remove();
+    if (th.dataset.key === st.sort.key) {
+      const s = document.createElement('span');
+      s.className = 'arrow';
+      s.textContent = st.sort.dir === 'asc' ? ' ▲' : ' ▼';
+      th.appendChild(s);
+    }
+  });
+}
+
+function updatePager(name) {
+  const st = state[name];
+  const info = document.querySelector(`[data-pageinfo="${name}"]`);
+  if (info) {
+    const cnt = st.totalCount != null ? ` · ${st.totalCount.toLocaleString()} total` : '';
+    info.textContent = st.rows.length ? `Page ${st.page} · ${st.rows.length} rows${cnt}` : '';
+  }
+  const prev = document.querySelector(`[data-prev="${name}"]`);
+  const next = document.querySelector(`[data-next="${name}"]`);
+  if (prev) prev.disabled = st.page <= 1;
+  if (next) next.disabled = !st.hasNext;
+}
+
+// ---- search + pagination (standard tabs) --------------------------------
+async function runSearch(name, direction) {
+  const cfg = TABS[name];
+  const st = state[name];
+  const btn = document.querySelector(`[data-search="${name}"]`);
+  if (btn) btn.disabled = true;
+  setStatus(name, 'Querying OpenFEC…');
+
+  try {
+    // Reset to page 1 on a fresh search.
+    if (!direction) {
+      st.page = 1;
+      st.cursorStack = [{}];
+      st.lastParams = cfg.buildParams();
+    } else if (direction === 'next') {
+      st.page += 1;
+    } else if (direction === 'prev') {
+      st.page = Math.max(1, st.page - 1);
+    }
+
+    const params = { ...st.lastParams };
+    if (cfg.pagination === 'offset') {
+      params.page = st.page;
+    } else {
+      // keyset: apply the cursor for the requested page.
+      const cursor = st.cursorStack[st.page - 1] || {};
+      Object.assign(params, cursor);
+    }
+
+    const data = await fecGet(cfg.endpoint, params);
+    const results = (data.results || []).map(cfg.mapRow);
+    st.rows = results;
+    st.totalCount = data.pagination ? data.pagination.count : null;
+
+    if (cfg.pagination === 'offset') {
+      const pg = data.pagination || {};
+      st.hasNext = pg.page != null && pg.pages != null ? pg.page < pg.pages : results.length === PER_PAGE;
+    } else {
+      const li = (data.pagination && data.pagination.last_indexes) || null;
+      // Store the cursor that fetches the NEXT page.
+      st.cursorStack[st.page] = li ? sanitizeCursor(li) : null;
+      st.hasNext = !!li && results.length === PER_PAGE;
+    }
+
+    renderTable(name);
+    const shown = results.length;
+    setStatus(name, shown ? `Showing ${shown} of ${st.totalCount != null ? st.totalCount.toLocaleString() : '?'} record(s).` : 'No records match these filters.');
+  } catch (e) {
+    setStatus(name, `Query failed: ${e.message}`, 'error');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+// last_indexes → plain query params (drop the sort_null_only helper flag unless set).
+function sanitizeCursor(li) {
+  const out = {};
+  for (const [k, v] of Object.entries(li)) {
+    if (v == null) continue;
+    out[k] = typeof v === 'boolean' ? String(v) : v;
+  }
+  return out;
+}
+
+// ---- CROSS-REFERENCE -----------------------------------------------------
+async function runXref() {
+  const name = 'xref';
+  const st = state[name];
+  const btn = document.querySelector(`[data-search="${name}"]`);
+  btn.disabled = true;
+  setStatus(name, 'Pulling FEC contributions…');
+
+  try {
+    const names = csvList(val('x_names'));
+    const employer = val('x_employer');
+    const states = csvList(val('x_states')).map((s) => s.toUpperCase());
+    const excludes = csvList(val('x_exclude')).map((s) => s.toLowerCase());
+    const naics = csvList(val('x_naics'));
+
+    if (!names.length) {
+      setStatus(name, 'Enter at least one contributor name.', 'error');
+      return;
+    }
+
+    // 1) One Schedule A query per name (employer-scoped, broad enough to catch
+    //    name-only matches for review). Bounded: names.length calls.
+    let all = [];
+    for (const nm of names) {
+      const params = { contributor_name: nm, per_page: 100, sort: '-contribution_receipt_date' };
+      if (employer) params.contributor_employer = employer;
+      const data = await fecGet('/schedules/schedule_a', params);
+      all = all.concat((data.results || []).map((r) => ({ ...r, _query_name: nm })));
+    }
+
+    // 2) Exclude unrelated names/employers (e.g. Fisher Investments / Ken Fisher).
+    const kept = all.filter((r) => {
+      const hay = `${r.contributor_name || ''} ${r.contributor_employer || ''}`.toLowerCase();
+      return !excludes.some((x) => x && hay.includes(x));
+    });
+
+    // 3) Confidence score (0–100) from employer / occupation / state / name.
+    const empLc = employer.toLowerCase();
+    const scored = kept.map((r) => {
+      const emp = (r.contributor_employer || '').toLowerCase();
+      const employerHit = empLc && emp.includes(empLc);
+      const stateHit = states.length ? states.includes((r.contributor_state || '').toUpperCase()) : false;
+      const occHit = !!(r.contributor_occupation && r.contributor_occupation.trim());
+
+      let score = 30; // queried by name → name signal present
+      if (employerHit) score += 40;
+      if (stateHit) score += 20;
+      if (occHit) score += 10;
+      score = Math.min(100, score);
+
+      const review = !employerHit && !stateHit; // name-only
+      return {
+        score,
+        review,
+        contributor_name: r.contributor_name,
+        contributor_employer: r.contributor_employer,
+        contributor_occupation: r.contributor_occupation,
+        contributor_state: r.contributor_state,
+        contribution_receipt_amount: r.contribution_receipt_amount,
+        contribution_receipt_date: r.contribution_receipt_date,
+        committee_name: r.committee_name,
+        committee_id: r.committee_id,
+        award_total: null
+      };
+    });
+
+    // 4) Join federal contract awards for the employer (recipient) via the
+    //    existing USAspending route. One lookup; total attached to every row.
+    let awardTotal = null;
+    let awardNote = '';
+    if (employer) {
+      setStatus(name, `${scored.length} contributions scored. Joining USAspending contract awards…`);
+      try {
+        const body = {
+          filters: {
+            recipient_search_text: [employer],
+            award_type_codes: ['A', 'B', 'C', 'D'],
+            time_period: [{ start_date: '2008-01-01', end_date: '2026-09-30' }]
+          },
+          fields: ['Award Amount', 'Recipient Name'],
+          page: 1,
+          limit: 100,
+          sort: 'Award Amount',
+          order: 'desc'
+        };
+        if (naics.length) body.filters.naics_codes = naics;
+        const usa = await usaPost('search/spending_by_award', body);
+        const awards = usa.results || [];
+        awardTotal = awards.reduce((s, a) => s + (Number(a['Award Amount']) || 0), 0);
+        awardNote = ` · USAspending: ${fmtUSD(awardTotal)} across ${awards.length}${awards.length === 100 ? '+' : ''} award(s) to "${employer}"`;
+      } catch (e) {
+        awardNote = ` · USAspending join failed (${e.message})`;
+      }
+    }
+    scored.forEach((r) => (r.award_total = awardTotal));
+
+    // Sort by score desc by default.
+    scored.sort((a, b) => b.score - a.score || (b.contribution_receipt_amount || 0) - (a.contribution_receipt_amount || 0));
+
+    st.rows = scored;
+    st.totalCount = scored.length;
+    st.hasNext = false;
+    st.page = 1;
+    renderTable(name);
+
+    const reviewCount = scored.filter((r) => r.review).length;
+    setStatus(name, `${scored.length} contribution(s) matched (${reviewCount} flagged REVIEW — name-only)${awardNote}.`);
+  } catch (e) {
+    setStatus(name, `Cross-reference failed: ${e.message}`, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+// Custom renderers for the xref table.
+TABS.xref = {
+  fmt: {
+    score: (r) => {
+      const cls = r.score >= 70 ? 'score-high' : r.score >= 40 ? 'score-med' : 'score-low';
+      return `<span class="score ${cls}">${r.score}</span>${r.review ? '<span class="flag-review">REVIEW</span>' : ''}`;
+    },
+    contribution_receipt_amount: (r) => fmtUSD(r.contribution_receipt_amount),
+    contribution_receipt_date: (r) => fmtDate(r.contribution_receipt_date),
+    committee_name: (r) => fecCommitteeLink(r.committee_id, r.committee_name),
+    award_total: (r) => (r.award_total == null ? '—' : fmtUSD(r.award_total))
+  }
+};
+
+// ---- export (CSV + Excel) -----------------------------------------------
+function exportRows(name, kind) {
+  const st = state[name];
+  if (!st.rows.length) {
+    setStatus(name, 'Nothing to export — table is empty.', 'warn');
+    return;
+  }
+  const cols = columnsFor(name);
+  // Build plain rows from raw values (not the HTML cells).
+  const aoa = sortedRows(name).map((r) => {
+    const o = {};
+    cols.forEach((c) => {
+      o[c.label] = r[c.key] == null ? '' : r[c.key];
+    });
+    return o;
+  });
+  const ws = XLSX.utils.json_to_sheet(aoa);
+  if (kind === 'csv') {
+    const csv = XLSX.utils.sheet_to_csv(ws);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `fec-${name}.csv`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  } else {
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, name);
+    XLSX.writeFile(wb, `fec-${name}.xlsx`);
+  }
+}
+
+// ---- wiring --------------------------------------------------------------
+function switchTab(name) {
+  document.querySelectorAll('.tab').forEach((t) => t.classList.toggle('active', t.dataset.tab === name));
+  document.querySelectorAll('.panel-view').forEach((v) => v.classList.toggle('active', v.id === `view-${name}`));
+}
+
+function wire() {
+  document.querySelectorAll('.tab').forEach((t) => t.addEventListener('click', () => switchTab(t.dataset.tab)));
+
+  document.querySelectorAll('[data-search]').forEach((b) => {
+    const name = b.dataset.search;
+    b.addEventListener('click', () => (name === 'xref' ? runXref() : runSearch(name)));
+  });
+  document.querySelectorAll('[data-next]').forEach((b) => b.addEventListener('click', () => runSearch(b.dataset.next, 'next')));
+  document.querySelectorAll('[data-prev]').forEach((b) => b.addEventListener('click', () => runSearch(b.dataset.prev, 'prev')));
+  document.querySelectorAll('[data-csv]').forEach((b) => b.addEventListener('click', () => exportRows(b.dataset.csv, 'csv')));
+  document.querySelectorAll('[data-xlsx]').forEach((b) => b.addEventListener('click', () => exportRows(b.dataset.xlsx, 'xlsx')));
+
+  // Column sort on every data table.
+  document.querySelectorAll('table.data').forEach((table) => {
+    const name = table.dataset.table;
+    table.querySelectorAll('thead th').forEach((th) => {
+      if (th.classList.contains('nosort')) return;
+      th.addEventListener('click', () => {
+        const st = state[name];
+        const key = th.dataset.key;
+        if (st.sort.key === key) st.sort.dir = st.sort.dir === 'asc' ? 'desc' : 'asc';
+        else {
+          st.sort.key = key;
+          st.sort.dir = th.classList.contains('num') ? 'desc' : 'asc';
+        }
+        renderTable(name);
+      });
+    });
+  });
+
+  // Enter key submits the active tab's search.
+  document.querySelectorAll('.filters input').forEach((inp) => {
+    inp.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter') return;
+      const view = inp.closest('.panel-view');
+      const btn = view && view.querySelector('[data-search]');
+      if (btn) btn.click();
+    });
+  });
+}
+
+wire();

--- a/public/projects/fec/index.html
+++ b/public/projects/fec/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>FEC Campaign Finance Explorer — OpenFEC</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div id="app">
+    <header class="app-head">
+      <h1>FEC Campaign Finance Explorer</h1>
+      <p class="sub">OpenFEC API · contributions, committees, candidates, expenditures, filings &amp; a contractor cross-reference</p>
+      <nav class="tabs" id="tabs">
+        <button class="tab active" data-tab="contributions">Contributions</button>
+        <button class="tab" data-tab="committees">Committees</button>
+        <button class="tab" data-tab="candidates">Candidates</button>
+        <button class="tab" data-tab="expenditures">Expenditures</button>
+        <button class="tab" data-tab="filings">Filings</button>
+        <button class="tab" data-tab="xref">Cross-Reference</button>
+      </nav>
+    </header>
+
+    <main>
+      <!-- ===================== CONTRIBUTIONS (Schedule A) ===================== -->
+      <section class="panel-view active" id="view-contributions">
+        <div class="filters">
+          <div class="field"><label class="field-label" for="c_name">Contributor name</label><input type="text" id="c_name" placeholder="e.g. Fisher" /></div>
+          <div class="field"><label class="field-label" for="c_employer">Employer</label><input type="text" id="c_employer" placeholder="e.g. Fisher Sand & Gravel" /></div>
+          <div class="field"><label class="field-label" for="c_occupation">Occupation</label><input type="text" id="c_occupation" placeholder="e.g. Executive" /></div>
+          <div class="field"><label class="field-label" for="c_state">State</label><input type="text" id="c_state" placeholder="2-letter, e.g. ND" maxlength="2" /></div>
+          <div class="field"><label class="field-label" for="c_committee">Committee ID</label><input type="text" id="c_committee" placeholder="e.g. C00401224" /></div>
+          <div class="field"><label class="field-label" for="c_min_date">Min date</label><input type="date" id="c_min_date" /></div>
+          <div class="field"><label class="field-label" for="c_max_date">Max date</label><input type="date" id="c_max_date" /></div>
+          <div class="field"><label class="field-label" for="c_min_amt">Min amount $</label><input type="number" id="c_min_amt" placeholder="0" /></div>
+          <div class="field"><label class="field-label" for="c_max_amt">Max amount $</label><input type="number" id="c_max_amt" placeholder="" /></div>
+          <div class="field actions"><button data-search="contributions">Search</button></div>
+        </div>
+        <div class="status" data-status="contributions"></div>
+        <div class="table-bar">
+          <h2>Contributions (Schedule A)</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="contributions"></span>
+            <button class="secondary" data-prev="contributions" disabled>‹ Prev</button>
+            <button class="secondary" data-next="contributions" disabled>Next ›</button>
+            <button class="btn-csv" data-csv="contributions">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="contributions">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="contributions">
+            <thead><tr>
+              <th data-key="contributor_name">Contributor</th>
+              <th data-key="contributor_employer">Employer</th>
+              <th data-key="contributor_occupation">Occupation</th>
+              <th data-key="contributor_state">State</th>
+              <th data-key="contribution_receipt_amount" class="num">Amount</th>
+              <th data-key="contribution_receipt_date">Date</th>
+              <th data-key="committee_name">Recipient committee</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No contributions match these filters.</div>
+        </div>
+      </section>
+
+      <!-- ===================== COMMITTEES ===================== -->
+      <section class="panel-view" id="view-committees">
+        <div class="filters">
+          <div class="field"><label class="field-label" for="cm_q">Name / keyword</label><input type="text" id="cm_q" placeholder="e.g. Cramer for Senate" /></div>
+          <div class="field"><label class="field-label" for="cm_state">State</label><input type="text" id="cm_state" placeholder="2-letter" maxlength="2" /></div>
+          <div class="field"><label class="field-label" for="cm_type">Committee type</label>
+            <select id="cm_type">
+              <option value="">Any</option>
+              <option value="P">P — Presidential</option>
+              <option value="H">H — House</option>
+              <option value="S">S — Senate</option>
+              <option value="N">N — PAC (nonqualified)</option>
+              <option value="Q">Q — PAC (qualified)</option>
+              <option value="O">O — Super PAC</option>
+              <option value="U">U — Single-candidate ind. exp.</option>
+              <option value="X">X — Party (nonqualified)</option>
+              <option value="Y">Y — Party (qualified)</option>
+            </select>
+          </div>
+          <div class="field actions"><button data-search="committees">Search</button></div>
+        </div>
+        <div class="status" data-status="committees"></div>
+        <div class="table-bar">
+          <h2>Committees</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="committees"></span>
+            <button class="secondary" data-prev="committees" disabled>‹ Prev</button>
+            <button class="secondary" data-next="committees" disabled>Next ›</button>
+            <button class="btn-csv" data-csv="committees">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="committees">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="committees">
+            <thead><tr>
+              <th data-key="name">Committee</th>
+              <th data-key="committee_id">ID</th>
+              <th data-key="committee_type_full">Type</th>
+              <th data-key="treasurer_name">Treasurer</th>
+              <th data-key="state">State</th>
+              <th data-key="party_full">Party</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No committees match these filters.</div>
+        </div>
+      </section>
+
+      <!-- ===================== CANDIDATES ===================== -->
+      <section class="panel-view" id="view-candidates">
+        <div class="filters">
+          <div class="field"><label class="field-label" for="cd_q">Name</label><input type="text" id="cd_q" placeholder="e.g. Cramer" /></div>
+          <div class="field"><label class="field-label" for="cd_state">State</label><input type="text" id="cd_state" placeholder="2-letter" maxlength="2" /></div>
+          <div class="field"><label class="field-label" for="cd_office">Office</label>
+            <select id="cd_office">
+              <option value="">Any</option>
+              <option value="P">President</option>
+              <option value="S">Senate</option>
+              <option value="H">House</option>
+            </select>
+          </div>
+          <div class="field"><label class="field-label" for="cd_cycle">Cycle</label><input type="number" id="cd_cycle" placeholder="e.g. 2026" step="2" /></div>
+          <div class="field actions"><button data-search="candidates">Search</button></div>
+        </div>
+        <div class="status" data-status="candidates"></div>
+        <div class="table-bar">
+          <h2>Candidates</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="candidates"></span>
+            <button class="secondary" data-prev="candidates" disabled>‹ Prev</button>
+            <button class="secondary" data-next="candidates" disabled>Next ›</button>
+            <button class="btn-csv" data-csv="candidates">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="candidates">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="candidates">
+            <thead><tr>
+              <th data-key="name">Candidate</th>
+              <th data-key="party_full">Party</th>
+              <th data-key="office_full">Office</th>
+              <th data-key="state">State</th>
+              <th data-key="district">Dist.</th>
+              <th data-key="incumbent_challenge_full">Status</th>
+              <th data-key="candidate_id">Links</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No candidates match these filters.</div>
+        </div>
+      </section>
+
+      <!-- ===================== EXPENDITURES (Schedule E) ===================== -->
+      <section class="panel-view" id="view-expenditures">
+        <div class="filters">
+          <div class="field"><label class="field-label" for="e_candidate">Candidate name</label><input type="text" id="e_candidate" placeholder="e.g. Cramer" /></div>
+          <div class="field"><label class="field-label" for="e_committee">Spending committee ID</label><input type="text" id="e_committee" placeholder="e.g. C00xxxxxx" /></div>
+          <div class="field"><label class="field-label" for="e_support">Support / oppose</label>
+            <select id="e_support"><option value="">Any</option><option value="S">Support</option><option value="O">Oppose</option></select>
+          </div>
+          <div class="field"><label class="field-label" for="e_min_date">Min date</label><input type="date" id="e_min_date" /></div>
+          <div class="field"><label class="field-label" for="e_max_date">Max date</label><input type="date" id="e_max_date" /></div>
+          <div class="field actions"><button data-search="expenditures">Search</button></div>
+        </div>
+        <div class="status" data-status="expenditures"></div>
+        <div class="table-bar">
+          <h2>Independent Expenditures (Schedule E)</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="expenditures"></span>
+            <button class="secondary" data-prev="expenditures" disabled>‹ Prev</button>
+            <button class="secondary" data-next="expenditures" disabled>Next ›</button>
+            <button class="btn-csv" data-csv="expenditures">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="expenditures">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="expenditures">
+            <thead><tr>
+              <th data-key="committee_name">Spending committee</th>
+              <th data-key="candidate_name">Candidate</th>
+              <th data-key="support_oppose_indicator">S/O</th>
+              <th data-key="expenditure_amount" class="num">Amount</th>
+              <th data-key="expenditure_date">Date</th>
+              <th data-key="expenditure_description">Purpose</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No expenditures match these filters.</div>
+        </div>
+      </section>
+
+      <!-- ===================== FILINGS ===================== -->
+      <section class="panel-view" id="view-filings">
+        <div class="filters">
+          <div class="field"><label class="field-label" for="f_committee">Committee ID</label><input type="text" id="f_committee" placeholder="e.g. C00401224" /></div>
+          <div class="field"><label class="field-label" for="f_candidate">Candidate ID</label><input type="text" id="f_candidate" placeholder="e.g. H6MN08138" /></div>
+          <div class="field"><label class="field-label" for="f_cycle">Cycle</label><input type="number" id="f_cycle" placeholder="e.g. 2026" step="2" /></div>
+          <div class="field actions"><button data-search="filings">Search</button></div>
+        </div>
+        <div class="status" data-status="filings"></div>
+        <div class="table-bar">
+          <h2>Filings</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="filings"></span>
+            <button class="secondary" data-prev="filings" disabled>‹ Prev</button>
+            <button class="secondary" data-next="filings" disabled>Next ›</button>
+            <button class="btn-csv" data-csv="filings">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="filings">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="filings">
+            <thead><tr>
+              <th data-key="committee_name">Committee</th>
+              <th data-key="form_type">Form</th>
+              <th data-key="document_description">Description</th>
+              <th data-key="coverage_end_date">Coverage end</th>
+              <th data-key="receipt_date">Received</th>
+              <th data-key="total_receipts" class="num">Total receipts</th>
+              <th data-key="pdf_url">PDF</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No filings match these filters.</div>
+        </div>
+      </section>
+
+      <!-- ===================== CROSS-REFERENCE ===================== -->
+      <section class="panel-view" id="view-xref">
+        <p class="intro">
+          <strong>Contributor ↔ Federal contract cross-reference.</strong>
+          Pulls FEC contributions (Schedule A) for a set of contributor names + employer, scores each row's
+          match confidence (0–100 from employer / occupation / state / name signals), and joins against
+          <code>USAspending.gov</code> federal contract awards for the same recipient — so donations and contract
+          dollars appear side by side. Defaults to the <strong>Fisher Sand &amp; Gravel</strong> principals
+          (ND/AZ), excluding the unrelated "Fisher Investments" / Ken Fisher. Name-only matches are flagged
+          <span class="flag-review">REVIEW</span>.
+        </p>
+        <div class="filters">
+          <div class="field" style="grid-column: 1 / -1;"><label class="field-label" for="x_names">Contributor names (comma-separated)</label><input type="text" id="x_names" value="Thomas Fisher, Tommy Fisher, Grant Fisher, Ryan Fisher" /></div>
+          <div class="field"><label class="field-label" for="x_employer">Employer contains</label><input type="text" id="x_employer" value="Fisher Sand" /></div>
+          <div class="field"><label class="field-label" for="x_states">States (comma-separated)</label><input type="text" id="x_states" value="ND, AZ" /></div>
+          <div class="field"><label class="field-label" for="x_exclude">Exclude employer/name contains</label><input type="text" id="x_exclude" value="Fisher Investments, Kenneth Fisher, Ken Fisher" /></div>
+          <div class="field"><label class="field-label" for="x_naics">USAspending NAICS (contract join)</label><input type="text" id="x_naics" value="237310, 237110, 237130" /></div>
+          <div class="field actions"><button data-search="xref">Run cross-reference</button></div>
+        </div>
+        <div class="status" data-status="xref"></div>
+        <div class="table-bar">
+          <h2>Matches</h2>
+          <div class="table-actions">
+            <span class="page-info" data-pageinfo="xref"></span>
+            <button class="btn-csv" data-csv="xref">⤓ CSV</button>
+            <button class="btn-xlsx" data-xlsx="xref">⤓ Excel</button>
+          </div>
+        </div>
+        <div class="table-scroll">
+          <table class="data" data-table="xref">
+            <thead><tr>
+              <th data-key="score" class="num">Score</th>
+              <th data-key="contributor_name">Contributor</th>
+              <th data-key="contributor_employer">Employer</th>
+              <th data-key="contributor_state">State</th>
+              <th data-key="contribution_receipt_amount" class="num">Donation</th>
+              <th data-key="contribution_receipt_date">Date</th>
+              <th data-key="committee_name">Recipient committee</th>
+              <th data-key="award_total" class="num">Fed. contract $ (recipient)</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="empty" hidden>No matches found.</div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="compliance">
+      <strong>Compliance &amp; use:</strong> FEC data is provided for research and transparency purposes only.
+      Under <strong>52 U.S.C. § 30111(a)(4)</strong>, contributor information (including names and addresses) may
+      <strong>not</strong> be used for commercial purposes or to solicit contributions or donations.
+      Sources: <a href="https://api.open.fec.gov/developers/" target="_blank" rel="noopener">OpenFEC API</a> ·
+      <a href="https://www.usaspending.gov/" target="_blank" rel="noopener">USAspending.gov</a>. Not an official government product.
+    </footer>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/public/projects/fec/style.css
+++ b/public/projects/fec/style.css
@@ -1,0 +1,164 @@
+/* FEC Campaign Finance Explorer — styling.
+ * Matches the look/feel of the Federal Award Explorer (spending) dashboard:
+ * system-ui type, #1565c0 primary buttons, green export, sticky table headers. */
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  height: 100%;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #1a1a1a;
+  background: #fff;
+}
+
+#app { display: flex; flex-direction: column; min-height: 100vh; }
+
+/* ---- Header + tabs ---- */
+header.app-head {
+  padding: 14px 18px 0;
+  border-bottom: 1px solid #eee;
+  background: #fafbfc;
+}
+header.app-head h1 { font-size: 18px; margin: 0; }
+header.app-head .sub { font-size: 12px; color: #666; margin: 3px 0 10px; }
+
+.tabs { display: flex; flex-wrap: wrap; gap: 2px; }
+.tab {
+  font-family: inherit;
+  border: 1px solid transparent;
+  border-bottom: none;
+  background: transparent;
+  color: #37474f;
+  font-size: 13px;
+  padding: 8px 14px;
+  cursor: pointer;
+  border-radius: 8px 8px 0 0;
+}
+.tab:hover { background: #eef2f6; }
+.tab.active {
+  background: #fff;
+  border-color: #ddd;
+  color: #0d47a1;
+  font-weight: 600;
+  margin-bottom: -1px;
+}
+
+/* ---- Panels ---- */
+main { flex: 1; display: flex; flex-direction: column; }
+.panel-view { display: none; flex: 1; flex-direction: column; }
+.panel-view.active { display: flex; }
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px 14px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #eee;
+  background: #fff;
+  align-items: end;
+}
+.field { display: flex; flex-direction: column; }
+.field-label { font-size: 12px; font-weight: 600; color: #333; margin-bottom: 4px; }
+.hint { font-size: 10px; color: #999; margin-top: 3px; }
+
+select, input[type="text"], input[type="number"], input[type="date"] {
+  width: 100%;
+  font-size: 13px;
+  padding: 6px 7px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-family: inherit;
+}
+
+.filters .actions { display: flex; gap: 8px; align-items: end; }
+
+button {
+  font-family: inherit;
+  border: none;
+  border-radius: 6px;
+  background: #1565c0;
+  color: #fff;
+  font-size: 13px;
+  padding: 8px 14px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+button:hover { background: #0d47a1; }
+button:disabled { background: #b0bec5; cursor: not-allowed; }
+
+button.secondary { background: #37474f; }
+button.secondary:hover { background: #263238; }
+
+.intro {
+  font-size: 12px;
+  color: #555;
+  background: #f1f6fb;
+  border: 1px solid #d7e6f5;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 12px 18px 0;
+  line-height: 1.45;
+}
+.intro code { background: #e3edf7; padding: 1px 4px; border-radius: 3px; }
+
+/* ---- Table bar + table ---- */
+.table-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 18px; border-bottom: 1px solid #eee; gap: 12px; flex-wrap: wrap;
+}
+.table-bar h2 { font-size: 15px; margin: 0; }
+.table-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.page-info { font-size: 12px; color: #666; margin-right: 4px; }
+.table-actions button { padding: 6px 10px; font-size: 12px; }
+.btn-csv { background: #00695c; }
+.btn-csv:hover { background: #004d40; }
+.btn-xlsx { background: #2e7d32; }
+.btn-xlsx:hover { background: #1b5e20; }
+
+.status { font-size: 12px; color: #555; padding: 6px 18px; min-height: 16px; }
+.status.error { color: #c62828; }
+.status.warn { color: #e65100; }
+
+.table-scroll { flex: 1; overflow: auto; position: relative; min-height: 200px; }
+
+table.data { border-collapse: collapse; width: 100%; font-size: 13px; }
+table.data thead th {
+  position: sticky; top: 0;
+  background: #f5f5f5;
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 2px solid #ddd;
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+table.data thead th:hover { background: #eceff1; }
+table.data thead th.num { text-align: right; }
+table.data thead th.nosort { cursor: default; }
+table.data thead th .arrow { color: #1565c0; font-size: 11px; }
+table.data tbody td { padding: 7px 12px; border-bottom: 1px solid #f0f0f0; vertical-align: top; }
+table.data tbody td.num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+table.data tbody tr:hover { background: #f9fbfd; }
+table.data a { color: #1565c0; text-decoration: none; }
+table.data a:hover { text-decoration: underline; }
+
+.empty { padding: 30px; text-align: center; color: #888; font-size: 14px; }
+
+/* Confidence score pills (cross-reference tab) */
+.score { display: inline-block; min-width: 34px; text-align: center; font-weight: 600; border-radius: 10px; padding: 1px 7px; font-size: 12px; }
+.score-high { background: #e8f5e9; color: #1b5e20; }
+.score-med  { background: #fff8e1; color: #e65100; }
+.score-low  { background: #ffebee; color: #b71c1c; }
+.flag-review { display: inline-block; background: #fff3e0; color: #e65100; border: 1px solid #ffcc80; border-radius: 4px; font-size: 10px; padding: 0 5px; margin-left: 6px; }
+
+/* ---- Compliance footer ---- */
+footer.compliance {
+  font-size: 11px; color: #777; line-height: 1.5;
+  border-top: 1px solid #eee; padding: 12px 18px; background: #fafbfc;
+}
+footer.compliance strong { color: #555; }
+
+@media (max-width: 640px) {
+  .filters { grid-template-columns: 1fr 1fr; }
+  header.app-head h1 { font-size: 16px; }
+}

--- a/src/pages/api/fec.js
+++ b/src/pages/api/fec.js
@@ -1,0 +1,165 @@
+/* Next.js API route: OpenFEC (FEC campaign-finance) proxy.
+ * (Mirrors the usaspending.js / wfs.js CORS-proxy pattern in this repo.)
+ *
+ * The OpenFEC API requires an `api_key` on every request. We keep that key
+ * SERVER-SIDE only (process.env.FEC_API_KEY) and never ship it to the browser.
+ * This route is a GENERIC proxy: the page passes an OpenFEC endpoint path plus
+ * arbitrary query params, we inject the key, forward to api.open.fec.gov/v1,
+ * and return the JSON verbatim.
+ *
+ *   GET /api/fec?endpoint=/candidates/search&q=cramer&per_page=20
+ *   GET /api/fec?endpoint=/schedules/schedule_a&contributor_name=fisher&...
+ *   GET /api/fec?health=1      → end-to-end key check (hits /candidates/search?q=cramer)
+ *
+ * Only an allow-listed set of endpoint prefixes may be proxied (no open proxy /
+ * SSRF). FEC pagination params (per_page, page, last_index,
+ * last_contribution_receipt_date, last_expenditure_date, etc.) are passed
+ * through untouched so keyset pagination works.
+ *
+ * Uses the global `fetch` (Node 18+).
+ */
+
+const API_BASE = 'https://api.open.fec.gov/v1';
+
+// Allow-list of endpoint PREFIXES. Any requested endpoint must start with one of
+// these (after normalizing to a leading slash, no trailing slash).
+const ALLOWED_PREFIXES = [
+  '/candidates',
+  '/candidate',
+  '/committees',
+  '/committee',
+  '/schedules/schedule_a',
+  '/schedules/schedule_b',
+  '/schedules/schedule_e',
+  '/filings',
+  '/elections',
+  '/totals'
+];
+
+// Params we never forward upstream (control params / our own key handling).
+const RESERVED = new Set(['endpoint', 'health', 'api_key']);
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+function applyCors(res) {
+  for (const [k, v] of Object.entries(CORS)) res.setHeader(k, v);
+}
+
+function sendJson(res, statusCode, obj) {
+  res.setHeader('Content-Type', 'application/json');
+  return res.status(statusCode).json(obj);
+}
+
+// Normalize "schedules/schedule_a/" → "/schedules/schedule_a" for prefix checks.
+function normalizeEndpoint(ep) {
+  let e = String(ep || '').trim();
+  if (!e.startsWith('/')) e = '/' + e;
+  e = e.replace(/\/+$/, ''); // strip trailing slashes
+  return e;
+}
+
+function isAllowed(endpoint) {
+  return ALLOWED_PREFIXES.some((p) => endpoint === p || endpoint.startsWith(p + '/'));
+}
+
+// Fetch upstream with retry/backoff on 429 (FEC rate limit). Returns the raw
+// Response. Honors Retry-After when present; otherwise exponential backoff.
+async function fetchWithBackoff(url, { maxRetries = 3 } = {}) {
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const r = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (r.status !== 429 || attempt >= maxRetries) return r;
+
+    const retryAfter = parseInt(r.headers.get('retry-after') || '', 10);
+    const waitMs = Number.isFinite(retryAfter) ? retryAfter * 1000 : Math.min(2000 * 2 ** attempt, 8000);
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    attempt += 1;
+  }
+}
+
+// OpenFEC requires a trailing slash on its endpoints.
+function buildUpstream(endpoint, query, apiKey) {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(query || {})) {
+    if (RESERVED.has(k)) continue;
+    if (v == null) continue;
+    // URLSearchParams handles repeated params (arrays) so multi-value filters work.
+    if (Array.isArray(v)) v.forEach((item) => params.append(k, item));
+    else params.append(k, v);
+  }
+  params.set('api_key', apiKey);
+  return `${API_BASE}${endpoint}/?${params.toString()}`;
+}
+
+export default async function handler(req, res) {
+  applyCors(res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end();
+  }
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method not allowed; use GET.' });
+  }
+
+  const apiKey = process.env.FEC_API_KEY;
+  if (!apiKey) {
+    return sendJson(res, 500, {
+      error: 'Server is missing FEC_API_KEY',
+      detail: 'Set FEC_API_KEY in .env.local (local) or as a Netlify environment variable (production).'
+    });
+  }
+
+  const qp = req.query || {};
+
+  // Health check: confirm the key works end to end.
+  if (qp.health) {
+    const url = buildUpstream('/candidates/search', { q: 'cramer', per_page: '1' }, apiKey);
+    try {
+      const r = await fetchWithBackoff(url);
+      const data = await r.json();
+      if (!r.ok) {
+        return sendJson(res, r.status, { ok: false, status: r.status, detail: data });
+      }
+      return sendJson(res, 200, {
+        ok: true,
+        endpoint: '/candidates/search?q=cramer',
+        count: data?.pagination?.count ?? null,
+        sample: data?.results?.[0]?.name ?? null
+      });
+    } catch (err) {
+      return sendJson(res, 502, { ok: false, error: 'Upstream FEC fetch failed', detail: String(err) });
+    }
+  }
+
+  const endpoint = normalizeEndpoint(qp.endpoint);
+  if (!qp.endpoint) {
+    return sendJson(res, 400, { error: "Missing 'endpoint' query param", allowed: ALLOWED_PREFIXES });
+  }
+  if (!isAllowed(endpoint)) {
+    return sendJson(res, 400, { error: `Endpoint '${endpoint}' is not allow-listed`, allowed: ALLOWED_PREFIXES });
+  }
+
+  const upstream = buildUpstream(endpoint, qp, apiKey);
+
+  try {
+    const r = await fetchWithBackoff(upstream);
+    const body = await r.text();
+    res.setHeader('Content-Type', 'application/json');
+    // Short cache so repeat/paged loads don't hammer the rate-limited upstream.
+    if (r.ok) res.setHeader('Cache-Control', 'public, max-age=60');
+    if (r.status === 429) {
+      return sendJson(res, 429, {
+        error: 'FEC rate limit hit (429) after retries',
+        detail: 'Too many requests to the OpenFEC API. Wait a moment and try again.'
+      });
+    }
+    return res.status(r.status).send(body);
+  } catch (err) {
+    return sendJson(res, 502, { error: 'Upstream FEC fetch failed', detail: String(err) });
+  }
+}

--- a/src/pages/projects/fec.tsx
+++ b/src/pages/projects/fec.tsx
@@ -1,0 +1,39 @@
+import Head from 'next/head';
+
+import BaseLayout from '@/components/layouts/BaseLayout';
+import { allContent } from '@/utils/content';
+
+// FEC Campaign Finance Explorer is a self-contained static app under
+// /public/projects/fec, embedded full-bleed via an iframe (keeps its own CDN
+// <script> tags + CSS sandboxed, same approach as the spending dashboard). Its
+// only backend call goes to the in-repo API route /api/fec, which injects the
+// server-side FEC_API_KEY.
+export default function FecPage(props: any) {
+    return (
+        <>
+            <Head>
+                <title>FEC Campaign Finance Explorer — OpenFEC</title>
+                <meta
+                    name="description"
+                    content="Explore FEC campaign-finance data: contributions, committees, candidates, independent expenditures, filings, and a contributor↔federal-contract cross-reference."
+                />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <BaseLayout {...props}>
+                <iframe
+                    src="/projects/fec/index.html"
+                    title="FEC Campaign Finance Explorer"
+                    className="block w-full border-0"
+                    style={{ height: '88vh', minHeight: '600px' }}
+                />
+            </BaseLayout>
+        </>
+    );
+}
+
+export function getStaticProps() {
+    const allData = allContent();
+    const pick = (modelName: string) => allData.find((o: any) => o.__metadata?.modelName === modelName) || null;
+    const global = JSON.parse(JSON.stringify({ site: pick('Config'), theme: pick('ThemeStyle') }));
+    return { props: { global, colors: 'colors-a' } };
+}


### PR DESCRIPTION
## Summary
Adds a general-purpose **FEC (campaign finance) explorer** at `/projects/fec`, following the same architecture as the existing Federal Award Explorer (`/projects/spending`): a self-contained static app embedded via iframe, backed by an in-repo API proxy.

## What's included
- **`src/pages/api/fec.js`** — generic, allow-listed OpenFEC proxy. Injects the server-side `FEC_API_KEY` (never exposed to the browser), forwards to `https://api.open.fec.gov/v1`, handles `429` with backoff, and passes FEC keyset pagination params through untouched. Allow-listed prefixes: `/candidates`, `/candidate`, `/committees`, `/committee`, `/schedules/schedule_a`, `/schedules/schedule_b`, `/schedules/schedule_e`, `/filings`, `/elections`, `/totals`. Health check: `GET /api/fec?health=1`.
- **`src/pages/projects/fec.tsx`** — BaseLayout iframe wrapper (mirrors `spending.tsx`).
- **`public/projects/fec/`** — static app (`index.html`, `app.js`, `style.css`) with six tabs and CSV + Excel export (SheetJS via CDN).
- Projects index card + README (key setup + compliance note).

## Tabs
1. **Contributions** (Schedule A) — name/employer/occupation/state/committee/date/amount filters, keyset pagination.
2. **Committees** — search by name/state/type.
3. **Candidates** — search by name/state/office/cycle, links to committees + FEC totals.
4. **Expenditures** (Schedule E) — independent expenditures, support/oppose.
5. **Filings** — recent filings lookup.
6. **Cross-Reference** — joins FEC contributions to USAspending federal contract awards (reusing the existing `/api/usaspending` route) with a 0–100 match confidence score; name-only matches flagged **REVIEW**. Defaults to the Fisher Sand & Gravel principals (ND/AZ), excluding the unrelated Fisher Investments / Ken Fisher.

## Validation (local `npm run dev`)
- `GET /api/fec?health=1` returns `ok:true, count:16, sample:"CRAMER, CYLE"`.
- All five FEC endpoints return data; allow-list blocks non-listed endpoints (400).
- Keyset pagination verified (forwards `last_index` + `sort_null_only`).
- USAspending join returns Fisher Sand & Gravel contract awards.
- `npm run build` passes (TypeScript + lint); `/projects/fec` builds as SSG.

## Deploy note
Set `FEC_API_KEY` as a Netlify environment variable before this goes live (see README). The key is **not** committed.

## Compliance
FEC data is for research/transparency only; contributor info may not be used for commercial purposes or to solicit donations (52 U.S.C. § 30111(a)(4)). Footer note added to the explorer and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
