### PR TITLE
WeatherMap: storm-motion arrows, point forecast, mobile/iOS

### DIFF
--- a/src/components/projects/WeatherMap/WeatherMap.module.css
+++ b/src/components/projects/WeatherMap/WeatherMap.module.css
@@ -65,9 +65,9 @@
     cursor: pointer;
     color: #1565c0;
 }
-.wrapper :global(.panel.collapsed .panel-body) {
-    display: none;
-}
+/* NOTE: the `.collapsed` collapse rule lives only inside the <=640px media query.
+ * The panel ships with class="panel collapsed" so it's collapsed from first paint
+ * on phones (no JS-timing flash); on wide screens `.collapsed` is a no-op. */
 .wrapper :global(.panel h2) {
     font-size: 12px;
     text-transform: uppercase;
@@ -293,34 +293,56 @@
 }
 
 /* --- narrow / phone layout (<=640px) -------------------------------------- */
-/* Capability-driven (viewport width + touch), not user-agent sniffing. */
+/* Capability-driven (viewport width), not user-agent sniffing. */
 @media (max-width: 640px) {
-    /* Full-bleed map; dvh (not vh) so iOS Safari's address bar can't cause overflow. */
+    /* Edge-to-edge map sized to fit BELOW the site header within one screen, so
+     * nothing requires page-scrolling (which would slide top-anchored overlays
+     * out of view). dvh (not vh) keeps it correct under the iOS address bar.
+     * The 96px budget covers a typical relative site header + page padding. */
     .wrapper {
-        height: 100dvh;
-        min-height: 0;
+        height: calc(100dvh - 96px);
+        min-height: 420px;
         border-radius: 0;
-        /* Break out of the page's horizontal padding for an edge-to-edge map. */
         margin-left: -1rem;
         margin-right: -1rem;
         width: calc(100% + 2rem);
     }
 
-    /* Controls become a collapsible top bar instead of a side panel. */
+    /* Controls become a BOTTOM sheet — thumb-reachable and never clipped by the
+     * top header. Collapsed by default to just its header bar; expands upward
+     * with internal scrolling so no control is ever cut off. */
     .wrapper :global(.panel) {
-        top: 0;
+        top: auto;
+        bottom: 0;
         left: 0;
         right: 0;
         width: auto;
-        max-height: 70dvh;
-        border-radius: 0 0 12px 12px;
+        max-height: 62dvh;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        border-radius: 12px 12px 0 0;
         padding: 10px 14px;
-        /* Respect the notch / status bar at the top. */
-        padding-top: calc(10px + env(safe-area-inset-top));
+        padding-bottom: calc(10px + env(safe-area-inset-bottom));
+    }
+    .wrapper :global(.panel.collapsed) {
+        overflow: hidden;
+    }
+    .wrapper :global(.panel.collapsed .panel-body) {
+        display: none;
+    }
+    /* Keep the title + toggle pinned and tappable while the body scrolls. */
+    .wrapper :global(.panel-head) {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background: rgba(255, 255, 255, 0.97);
+        padding-bottom: 6px;
     }
     .wrapper :global(.panel-toggle) {
         display: inline-block;
         min-height: 44px;
+        padding: 8px 14px;
+        font-size: 14px;
     }
 
     /* Bigger tap targets. */
@@ -338,14 +360,17 @@
         font-size: 15px;
     }
 
-    /* Forecast becomes a bottom sheet, clear of the home-bar inset. */
+    /* Forecast sheet sits just ABOVE the collapsed controls bar (which the
+     * forecast handler auto-collapses to), so the two never overlap. */
     .wrapper :global(.forecast) {
         left: 0;
         right: 0;
-        bottom: 0;
+        top: auto;
+        bottom: calc(72px + env(safe-area-inset-bottom));
         width: auto;
+        max-height: 48dvh;
+        overflow-y: auto;
         border-radius: 12px 12px 0 0;
-        padding-bottom: env(safe-area-inset-bottom);
     }
     .wrapper :global(.forecast-close) {
         min-width: 44px;

--- a/src/components/projects/WeatherMap/WeatherMap.module.css
+++ b/src/components/projects/WeatherMap/WeatherMap.module.css
@@ -40,9 +40,33 @@
     padding: 14px 16px;
     backdrop-filter: blur(4px);
 }
+.wrapper :global(.panel-head) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
 .wrapper :global(.panel h1) {
     font-size: 16px;
     margin: 0 0 10px;
+}
+.wrapper :global(.panel-head h1) {
+    margin-bottom: 0;
+}
+
+/* Collapse toggle: hidden on wide screens, shown as a button on narrow ones. */
+.wrapper :global(.panel-toggle) {
+    display: none;
+    border: 1px solid #cfd8dc;
+    background: #fff;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    color: #1565c0;
+}
+.wrapper :global(.panel.collapsed .panel-body) {
+    display: none;
 }
 .wrapper :global(.panel h2) {
     font-size: 12px;
@@ -83,7 +107,8 @@
     width: 100%;
 }
 
-.wrapper :global(button#refresh) {
+.wrapper :global(button#refresh),
+.wrapper :global(button#locate) {
     width: 100%;
     padding: 8px;
     border: none;
@@ -92,13 +117,27 @@
     color: #fff;
     font-size: 13px;
     cursor: pointer;
+    margin-bottom: 6px;
+}
+.wrapper :global(button#locate) {
+    background: #2e7d32;
 }
 .wrapper :global(button#refresh:hover) {
     background: #0d47a1;
 }
-.wrapper :global(button#refresh:disabled) {
+.wrapper :global(button#locate:hover) {
+    background: #1b5e20;
+}
+.wrapper :global(button#refresh:disabled),
+.wrapper :global(button#locate:disabled) {
     background: #90a4ae;
     cursor: progress;
+}
+
+.wrapper :global(.motion-note) {
+    font-size: 11px;
+    color: #555;
+    line-height: 1.3;
 }
 
 .wrapper :global(.status) {
@@ -175,4 +214,141 @@
 }
 .wrapper :global(.popup a) {
     color: #1565c0;
+}
+.wrapper :global(.popup .sub) {
+    margin: 0 0 6px;
+    font-size: 12px;
+    color: #444;
+}
+
+/* --- point forecast card -------------------------------------------------- */
+/* Wide screens: floating card, bottom-left (clear of nav + scale controls). */
+.wrapper :global(.forecast) {
+    position: absolute;
+    left: 12px;
+    bottom: 28px;
+    z-index: 11;
+    width: 240px;
+    background: rgba(255, 255, 255, 0.97);
+    border-radius: 10px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    overflow: hidden;
+}
+.wrapper :global(.forecast-head) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: #1565c0;
+    color: #fff;
+}
+.wrapper :global(.forecast-title) {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.wrapper :global(.forecast-close) {
+    border: none;
+    background: transparent;
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px;
+}
+.wrapper :global(.forecast-body) {
+    padding: 10px 12px 12px;
+}
+.wrapper :global(.fc-place) {
+    font-size: 13px;
+    font-weight: 600;
+    color: #222;
+}
+.wrapper :global(.fc-temp) {
+    font-size: 30px;
+    font-weight: 700;
+    color: #0d47a1;
+    line-height: 1.1;
+    margin: 2px 0;
+}
+.wrapper :global(.fc-period) {
+    font-size: 12px;
+    color: #555;
+}
+.wrapper :global(.fc-short) {
+    font-size: 13px;
+    color: #222;
+    margin: 4px 0 2px;
+}
+.wrapper :global(.fc-wind) {
+    font-size: 12px;
+    color: #555;
+}
+.wrapper :global(.fc-loading),
+.wrapper :global(.fc-empty) {
+    font-size: 13px;
+    color: #555;
+    margin: 0;
+}
+
+/* --- narrow / phone layout (<=640px) -------------------------------------- */
+/* Capability-driven (viewport width + touch), not user-agent sniffing. */
+@media (max-width: 640px) {
+    /* Full-bleed map; dvh (not vh) so iOS Safari's address bar can't cause overflow. */
+    .wrapper {
+        height: 100dvh;
+        min-height: 0;
+        border-radius: 0;
+        /* Break out of the page's horizontal padding for an edge-to-edge map. */
+        margin-left: -1rem;
+        margin-right: -1rem;
+        width: calc(100% + 2rem);
+    }
+
+    /* Controls become a collapsible top bar instead of a side panel. */
+    .wrapper :global(.panel) {
+        top: 0;
+        left: 0;
+        right: 0;
+        width: auto;
+        max-height: 70dvh;
+        border-radius: 0 0 12px 12px;
+        padding: 10px 14px;
+        /* Respect the notch / status bar at the top. */
+        padding-top: calc(10px + env(safe-area-inset-top));
+    }
+    .wrapper :global(.panel-toggle) {
+        display: inline-block;
+        min-height: 44px;
+    }
+
+    /* Bigger tap targets. */
+    .wrapper :global(.toggle) {
+        min-height: 44px;
+        font-size: 15px;
+    }
+    .wrapper :global(.toggle input) {
+        width: 22px;
+        height: 22px;
+    }
+    .wrapper :global(button#refresh),
+    .wrapper :global(button#locate) {
+        min-height: 44px;
+        font-size: 15px;
+    }
+
+    /* Forecast becomes a bottom sheet, clear of the home-bar inset. */
+    .wrapper :global(.forecast) {
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: auto;
+        border-radius: 12px 12px 0 0;
+        padding-bottom: env(safe-area-inset-bottom);
+    }
+    .wrapper :global(.forecast-close) {
+        min-width: 44px;
+        min-height: 44px;
+    }
 }

--- a/src/components/projects/WeatherMap/WeatherMap.tsx
+++ b/src/components/projects/WeatherMap/WeatherMap.tsx
@@ -119,6 +119,56 @@ export default function WeatherMap() {
         let loadedHazards: any[] = [];
         let loadedStorms: any[] = [];
         let lastUpdated = '';
+        // The set of states the last fetch was bounded to; used to refetch only
+        // when panning into a different region.
+        let lastAreaKey = '';
+
+        // Generously-padded [W, S, E, N] bbox per US state/territory. Used only to
+        // pick which states to request alerts for (api.weather.gov has no bbox
+        // filter, but accepts ?area=<state codes>). Over-inclusion is safe — the
+        // exact in-view count is still computed against real geometry below.
+        const STATE_BBOX: Record<string, [number, number, number, number]> = {
+            AL: [-89, 30, -84.5, 35.5], AZ: [-115, 31, -109, 37.5], AR: [-94.8, 32.5, -89.5, 36.7],
+            CA: [-124.6, 32, -114, 42.4], CO: [-109.4, 36.8, -101.5, 41.3], CT: [-73.9, 40.9, -71.7, 42.2],
+            DE: [-75.9, 38.4, -74.9, 39.9], DC: [-77.2, 38.7, -76.8, 39.1], FL: [-87.8, 24, -79.8, 31.2],
+            GA: [-85.8, 30.3, -80.7, 35.2], ID: [-117.3, 41.9, -110.9, 49.1], IL: [-91.6, 36.9, -87.4, 42.6],
+            IN: [-88.2, 37.7, -84.7, 41.9], IA: [-96.7, 40.3, -90, 43.6], KS: [-102.2, 36.9, -94.5, 40.1],
+            KY: [-89.6, 36.4, -81.9, 39.2], LA: [-94.1, 28.8, -88.7, 33.1], ME: [-71.2, 42.9, -66.8, 47.6],
+            MD: [-79.6, 37.8, -74.9, 39.8], MA: [-73.6, 41.1, -69.8, 42.9], MI: [-90.5, 41.6, -82.3, 48.4],
+            MN: [-97.3, 43.4, -89.4, 49.5], MS: [-91.7, 30, -88, 35], MO: [-95.9, 35.9, -89, 40.7],
+            MT: [-116.1, 44.3, -104, 49.1], NE: [-104.1, 39.9, -95.2, 43.1], NV: [-120.1, 35, -114, 42.1],
+            NH: [-72.6, 42.6, -70.6, 45.4], NJ: [-75.6, 38.8, -73.8, 41.4], NM: [-109.1, 31.2, -102.9, 37.1],
+            NY: [-79.8, 40.4, -71.8, 45.1], NC: [-84.4, 33.7, -75.4, 36.7], ND: [-104.1, 45.8, -96.5, 49.1],
+            OH: [-84.9, 38.3, -80.4, 42.4], OK: [-103.1, 33.5, -94.4, 37.1], OR: [-124.6, 41.9, -116.4, 46.4],
+            PA: [-80.6, 39.6, -74.6, 42.3], RI: [-71.9, 41.1, -71.1, 42.1], SC: [-83.4, 32, -78.5, 35.3],
+            SD: [-104.1, 42.4, -96.4, 46], TN: [-90.4, 34.9, -81.6, 36.7], TX: [-106.7, 25.7, -93.4, 36.6],
+            UT: [-114.1, 36.9, -109, 42.1], VT: [-73.5, 42.7, -71.4, 45.1], VA: [-83.7, 36.5, -75.1, 39.5],
+            WA: [-124.9, 45.5, -116.9, 49.1], WV: [-82.7, 37.1, -77.7, 40.7], WI: [-92.9, 42.4, -86.8, 47.1],
+            WY: [-111.1, 40.9, -104, 45.1], AK: [-179.2, 51, -129.9, 71.5], HI: [-160.3, 18.8, -154.8, 22.3],
+            PR: [-67.3, 17.9, -65.6, 18.6]
+        };
+
+        function statesInView(b: maplibregl.LngLatBounds): string[] {
+            const W = b.getWest(), E = b.getEast(), S = b.getSouth(), N = b.getNorth();
+            const out: string[] = [];
+            for (const [code, bb] of Object.entries(STATE_BBOX)) {
+                if (!(bb[2] < W || bb[0] > E || bb[3] < S || bb[1] > N)) out.push(code);
+            }
+            return out;
+        }
+
+        // Build the alerts request URL, bounded to the states in view when that's a
+        // tractable regional set; otherwise national (zoomed-out or over open water,
+        // where marine alerts have no state area). Returns the area key for change
+        // detection so we only refetch when the region actually changes.
+        function alertsRequest(): { url: string; areaKey: string } {
+            const codes = statesInView(map.getBounds()).sort();
+            // 1..18 states -> bound the fetch; else national (full coverage / marine).
+            if (codes.length >= 1 && codes.length <= 18) {
+                return { url: `/api/alerts/?resource=alerts&area=${codes.join(',')}`, areaKey: codes.join(',') };
+            }
+            return { url: '/api/alerts/?resource=alerts', areaKey: '*' };
+        }
 
         // Id of the basemap's lowest symbol (label) layer.
         let labelLayerId: string | undefined;
@@ -294,8 +344,12 @@ export default function WeatherMap() {
             const btn = document.getElementById('refresh') as HTMLButtonElement | null;
             if (btn) btn.disabled = true;
             try {
-                // Trailing slash: next.config has trailingSlash:true, so this avoids a 308 redirect hop.
-                const res = await fetch('/api/alerts/?resource=alerts', { headers: { Accept: 'application/geo+json' } });
+                // Bound the fetch to the region in view so we never pull the whole
+                // (cap-prone) national feed for a regional map. Trailing slash:
+                // next.config has trailingSlash:true, so this avoids a 308 hop.
+                const req = alertsRequest();
+                lastAreaKey = req.areaKey;
+                const res = await fetch(req.url, { headers: { Accept: 'application/geo+json' } });
                 if (!res.ok) throw new Error(`HTTP ${res.status}`);
                 const geojson = await res.json();
                 const all: any[] = Array.isArray(geojson.features) ? geojson.features : [];
@@ -370,7 +424,7 @@ export default function WeatherMap() {
             const arrowNote = aIn ? ` · ${aIn} storm-motion arrow(s)` : '';
             const total = loadedWarnings.length + loadedHazards.length;
             if (wIn === 0 && hIn === 0) {
-                setStatus(`No alerts in view${total ? ` (${total} active in the US)` : ''}. · updated ${lastUpdated}`);
+                setStatus(`No alerts in view${total ? ` (${total} loaded for this region)` : ''} · updated ${lastUpdated}`);
             } else {
                 setStatus(`${wIn} warning(s), ${hIn} watch/hazard(s) in view${arrowNote} · updated ${lastUpdated}`);
             }
@@ -719,8 +773,18 @@ export default function WeatherMap() {
             // Tap/click anywhere on the map -> point forecast for that spot.
             map.on('click', (e: any) => loadForecast(e.lngLat.lat, e.lngLat.lng));
 
-            // Recount in-view alerts when the user pans/zooms.
-            map.on('moveend', updateAlertStatus);
+            // On pan/zoom: recount in-view instantly from cached data, and if the
+            // user moved into a different region, refetch that region (debounced).
+            let regionTimer: ReturnType<typeof setTimeout> | undefined;
+            map.on('moveend', () => {
+                updateAlertStatus();
+                if (regionTimer) clearTimeout(regionTimer);
+                regionTimer = setTimeout(() => {
+                    const codes = statesInView(map.getBounds()).sort();
+                    const key = codes.length >= 1 && codes.length <= 18 ? codes.join(',') : '*';
+                    if (key !== lastAreaKey) refreshAlerts();
+                }, 700);
+            });
 
             // Alerts change frequently; auto-refresh every 5 minutes.
             refreshIntervalId = setInterval(() => {

--- a/src/components/projects/WeatherMap/WeatherMap.tsx
+++ b/src/components/projects/WeatherMap/WeatherMap.tsx
@@ -113,6 +113,13 @@ export default function WeatherMap() {
         let radarTimeISO = roundedNowISO(); // changing this busts the WMS tile cache → fresh radar
         const visible: Record<string, boolean> = { radar: true, precip: false, warnings: true, hazards: true };
 
+        // Cached alert features from the last fetch, so the status line can recount
+        // what's *in the current map view* on pan/zoom (without re-fetching).
+        let loadedWarnings: any[] = [];
+        let loadedHazards: any[] = [];
+        let loadedStorms: any[] = [];
+        let lastUpdated = '';
+
         // Id of the basemap's lowest symbol (label) layer.
         let labelLayerId: string | undefined;
 
@@ -311,18 +318,61 @@ export default function WeatherMap() {
                 const sSrc = map.getSource(STORM_SOURCE) as any;
                 if (sSrc) sSrc.setData(storms);
 
-                const arrowNote = storms.features.length ? ` · ${storms.features.length} storm-motion arrow(s)` : '';
-                if (warnings.length === 0 && hazards.length === 0) {
-                    setStatus(`No active alerts.${arrowNote}`);
-                } else {
-                    setStatus(
-                        `${warnings.length} warning(s), ${hazards.length} watch/hazard(s)${arrowNote} · updated ${new Date().toLocaleTimeString()}`
-                    );
-                }
+                // Cache for viewport-scoped recounting on pan/zoom.
+                loadedWarnings = warnings;
+                loadedHazards = hazards;
+                loadedStorms = storms.features;
+                lastUpdated = new Date().toLocaleTimeString();
+                updateAlertStatus();
             } catch (e: any) {
                 setStatus(`Alert fetch failed: ${e.message}`, true);
             } finally {
                 if (btn) btn.disabled = false;
+            }
+        }
+
+        // Geographic bbox [w, s, e, n] of a GeoJSON geometry's coordinates.
+        function geomBbox(geom: any): [number, number, number, number] | null {
+            if (!geom || !geom.coordinates) return null;
+            let w = 180,
+                s = 90,
+                e = -180,
+                n = -90;
+            const visit = (c: any) => {
+                if (typeof c[0] === 'number') {
+                    const [lon, lat] = c;
+                    if (lon < w) w = lon;
+                    if (lon > e) e = lon;
+                    if (lat < s) s = lat;
+                    if (lat > n) n = lat;
+                } else for (const x of c) visit(x);
+            };
+            visit(geom.coordinates);
+            return [w, s, e, n];
+        }
+
+        function featureInView(f: any, b: maplibregl.LngLatBounds) {
+            const bb = geomBbox(f.geometry);
+            if (!bb) return false;
+            // bbox-vs-bounds intersection test.
+            return !(bb[2] < b.getWest() || bb[0] > b.getEast() || bb[3] < b.getSouth() || bb[1] > b.getNorth());
+        }
+
+        // Recompute the status line from cached features, scoped to the current view.
+        // The bug we're fixing: the old line reported all loaded (national) alerts,
+        // and could appear to show the same number for both categories.
+        function updateAlertStatus() {
+            if (!lastUpdated) return; // nothing fetched yet
+            const b = map.getBounds();
+            const wIn = loadedWarnings.filter((f) => featureInView(f, b)).length;
+            const hIn = loadedHazards.filter((f) => featureInView(f, b)).length;
+            const aIn = loadedStorms.filter((f) => b.contains(f.geometry.coordinates as [number, number])).length;
+            const arrowNote = aIn ? ` · ${aIn} storm-motion arrow(s)` : '';
+            const total = loadedWarnings.length + loadedHazards.length;
+            if (wIn === 0 && hIn === 0) {
+                setStatus(`No alerts in view${total ? ` (${total} active in the US)` : ''}. · updated ${lastUpdated}`);
+            } else {
+                setStatus(`${wIn} warning(s), ${hIn} watch/hazard(s) in view${arrowNote} · updated ${lastUpdated}`);
             }
         }
 
@@ -464,8 +514,9 @@ export default function WeatherMap() {
                     'icon-rotation-alignment': 'map',
                     'icon-allow-overlap': true,
                     'icon-ignore-placement': true,
-                    // Scale by speed: faster storm -> bigger arrow.
-                    'icon-size': ['interpolate', ['linear'], ['get', 'speedKt'], 0, 0.6, 60, 1.5],
+                    // Scale by speed: faster storm -> bigger arrow. Floor kept high
+                    // enough to stay legible on dense high-DPR phone screens.
+                    'icon-size': ['interpolate', ['linear'], ['get', 'speedKt'], 0, 0.9, 60, 1.8],
                     'text-field': ['concat', ['to-string', ['get', 'speedMph']], ' mph'],
                     'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
                     'text-size': 11,
@@ -505,6 +556,9 @@ export default function WeatherMap() {
         }
 
         async function loadForecast(lat: number, lon: number) {
+            // On phones the controls + forecast are both bottom sheets; collapse the
+            // controls so the forecast sheet is unobstructed.
+            if (narrowMq.matches) setPanelCollapsed(true);
             setForecastBody('<p class="fc-loading">Loading forecast…</p>');
             try {
                 const pRes = await fetch(`/api/alerts/?resource=point&lat=${lat.toFixed(4)}&lon=${lon.toFixed(4)}`);
@@ -593,7 +647,8 @@ export default function WeatherMap() {
             }
         }
 
-        // Narrow-viewport behavior: collapse the panel into a top bar by default.
+        // Narrow-viewport behavior. The panel ships collapsed (class in markup), so
+        // we only need to toggle on tap; no JS-timing default is required.
         const narrowMq = window.matchMedia('(max-width: 640px)');
         function setPanelCollapsed(collapsed: boolean) {
             const panel = document.getElementById('panel');
@@ -627,7 +682,7 @@ export default function WeatherMap() {
 
             (document.getElementById('locate') as HTMLButtonElement).addEventListener('click', useMyLocation);
 
-            // Collapsible panel (matters on narrow screens; harmless on wide).
+            // Collapsible panel (matters on narrow screens; the toggle is hidden on wide).
             const toggle = document.getElementById('panel-toggle');
             if (toggle)
                 toggle.addEventListener('click', () => {
@@ -642,12 +697,6 @@ export default function WeatherMap() {
                     const card = document.getElementById('forecast');
                     if (card) card.hidden = true;
                 });
-
-            // Default to collapsed on phones; expanded on wide. React to rotation/resize.
-            setPanelCollapsed(narrowMq.matches);
-            const onMq = (ev: MediaQueryListEvent) => setPanelCollapsed(ev.matches);
-            if (narrowMq.addEventListener) narrowMq.addEventListener('change', onMq);
-            else narrowMq.addListener(onMq); // older Safari
         }
 
         // --- boot ----------------------------------------------------------------
@@ -670,6 +719,9 @@ export default function WeatherMap() {
             // Tap/click anywhere on the map -> point forecast for that spot.
             map.on('click', (e: any) => loadForecast(e.lngLat.lat, e.lngLat.lng));
 
+            // Recount in-view alerts when the user pans/zooms.
+            map.on('moveend', updateAlertStatus);
+
             // Alerts change frequently; auto-refresh every 5 minutes.
             refreshIntervalId = setInterval(() => {
                 refreshRadar();
@@ -690,11 +742,11 @@ export default function WeatherMap() {
         <div className={styles.wrapper}>
             <div id="map" ref={mapRef}></div>
 
-            <div id="panel" className="panel">
+            <div id="panel" className="panel collapsed">
                 <div className="panel-head">
                     <h1>Weather Map</h1>
-                    <button id="panel-toggle" type="button" className="panel-toggle" aria-expanded="true" aria-label="Toggle controls">
-                        Layers
+                    <button id="panel-toggle" type="button" className="panel-toggle" aria-expanded="false" aria-label="Toggle controls">
+                        Layers ▾
                     </button>
                 </div>
 

--- a/src/components/projects/WeatherMap/WeatherMap.tsx
+++ b/src/components/projects/WeatherMap/WeatherMap.tsx
@@ -2,9 +2,18 @@
  *
  * MapLibre is a real npm dependency (imported below), NOT the unpkg window global.
  * The original vanilla app.js logic runs inside useEffect after mount and is torn
- * down on unmount. Fetches go to the in-repo API route /api/wfs (was the Netlify
- * function /.netlify/functions/wfs). All map/panel CSS is scoped to .wrapper via
- * WeatherMap.module.css — nothing targets html/body.
+ * down on unmount. All map/panel CSS is scoped to .wrapper via WeatherMap.module.css
+ * — nothing targets html/body.
+ *
+ * Data sources:
+ *   - Radar / precip-type rasters: NOAA/NWS nowCOAST WMS (direct).
+ *   - Alerts (warnings, watches, hazards) + storm motion: api.weather.gov, proxied
+ *     through /api/alerts (the proxy attaches the mandatory User-Agent header).
+ *   - Point forecast: api.weather.gov /points -> /gridpoints forecast, same proxy.
+ *
+ * Storm-motion arrows: convective alerts (tornado / severe-tstorm / some flash-flood
+ * warnings) carry `parameters.eventMotionDescription`. dirDeg there is the direction
+ * the storm moves *from* (meteorological); the heading we draw is (dirDeg + 180).
  */
 import { useEffect, useRef } from 'react';
 import maplibregl from 'maplibre-gl';
@@ -38,11 +47,17 @@ export default function WeatherMap() {
             }
         };
 
-        // WFS vector layers, fetched through the proxy.
-        const WFS_LAYERS: Record<string, any> = {
-            warnings: { proxyLayer: 'wwa:warnings', sourceId: 'warnings-src', fillId: 'warnings-fill', lineId: 'warnings-line' },
-            hazards: { proxyLayer: 'wwa:hazards', sourceId: 'hazards-src', fillId: 'hazards-fill', lineId: 'hazards-line' }
+        // Vector alert layers. Both are now fed from a single api.weather.gov fetch
+        // (split client-side: anything ending in "Warning" -> warnings, else hazards).
+        const ALERT_LAYERS: Record<string, any> = {
+            warnings: { sourceId: 'warnings-src', fillId: 'warnings-fill', lineId: 'warnings-line' },
+            hazards: { sourceId: 'hazards-src', fillId: 'hazards-fill', lineId: 'hazards-line' }
         };
+
+        // Storm-motion arrow layer (symbol layer, above the polygons).
+        const STORM_SOURCE = 'storms-src';
+        const STORM_LAYER = 'storms-arrows';
+        const STORM_ICON = 'storm-arrow';
 
         // Color by VTEC phenomenon code (`phenom`), with a sensible fallback.
         const PHENOM_COLORS: Record<string, string> = {
@@ -69,6 +84,28 @@ export default function WeatherMap() {
             expr.push(DEFAULT_ALERT_COLOR);
             return expr;
         };
+
+        // Map an api.weather.gov `event` string to one of the 2-letter phenom codes
+        // above so the existing color ramp + legend keep working unchanged.
+        function phenomFromEvent(event: string): string {
+            const e = (event || '').toLowerCase();
+            if (e.includes('tornado')) return 'TO';
+            if (e.includes('severe thunderstorm')) return 'SV';
+            if (e.includes('flash flood')) return 'FF';
+            if (e.includes('areal flood') || e.includes('flood advisory')) return 'FA';
+            if (e.includes('flood')) return 'FL';
+            if (e.includes('marine') || e.includes('small craft')) return 'MA';
+            if (e.includes('blizzard')) return 'BZ';
+            if (e.includes('winter storm') || e.includes('ice storm')) return 'WS';
+            if (e.includes('winter weather') || e.includes('snow')) return 'WW';
+            if (e.includes('high wind')) return 'HW';
+            if (e.includes('wind chill')) return 'WC';
+            if (e.includes('wind')) return 'WI';
+            if (e.includes('excessive heat')) return 'EH';
+            if (e.includes('heat')) return 'HT';
+            if (e.includes('fog')) return 'FG';
+            return ''; // -> DEFAULT_ALERT_COLOR
+        }
 
         const GREENVILLE: [number, number] = [-82.4, 34.85];
 
@@ -144,7 +181,7 @@ export default function WeatherMap() {
                 tileSize: 256,
                 attribution: 'NOAA/NWS nowCOAST'
             });
-            const before = map.getLayer(WFS_LAYERS.warnings.fillId) ? WFS_LAYERS.warnings.fillId : labelLayerId;
+            const before = map.getLayer(ALERT_LAYERS.warnings.fillId) ? ALERT_LAYERS.warnings.fillId : labelLayerId;
             map.addLayer(
                 {
                     id: cfg.layerId,
@@ -168,33 +205,119 @@ export default function WeatherMap() {
             el.classList.toggle('error', isError);
         }
 
-        // --- WFS alerts ----------------------------------------------------------
-        async function fetchAlerts(key: string) {
-            const cfg = WFS_LAYERS[key];
-            const url = `/api/wfs?layer=${encodeURIComponent(cfg.proxyLayer)}`;
-            const res = await fetch(url, { headers: { Accept: 'application/json' } });
-            if (!res.ok) throw new Error(`${cfg.proxyLayer}: HTTP ${res.status}`);
-            const geojson = await res.json();
-            const src = map.getSource(cfg.sourceId) as any;
-            if (src) src.setData(geojson);
-            return geojson.features ? geojson.features.length : 0;
+        // --- alerts (api.weather.gov) --------------------------------------------
+        // Normalize an api.weather.gov alert feature's properties to the compact
+        // shape the popup + color ramp expect, and stamp in the derived phenom code.
+        function normalizeAlertProps(raw: any) {
+            const usableUrl = raw.web && raw.web !== 'http://www.weather.gov' ? raw.web : raw['@id'] || '';
+            return {
+                event: raw.event || 'Alert',
+                phenom: phenomFromEvent(raw.event),
+                headline: raw.headline || '',
+                severity: raw.severity || '',
+                senderName: raw.senderName || '',
+                messageType: raw.messageType || '',
+                onset: raw.onset || raw.effective || '',
+                ends: raw.ends || '',
+                expires: raw.expires || '',
+                url: usableUrl
+            };
+        }
+
+        function isWarning(event: string) {
+            return /warning$/i.test((event || '').trim());
+        }
+
+        // eventMotionDescription, e.g.
+        //   "2026-06-29T21:17:00-00:00...storm...024DEG...17KT...33.61,-82.89"
+        // (the "storm" token is extra vs. the docs; some strings list several
+        // space-separated lat,lon points for a line of storms). Parse defensively.
+        function parseMotion(emd: string): { dirDeg: number; speedKt: number; points: [number, number][] } | null {
+            if (!emd || typeof emd !== 'string') return null;
+            const dirM = emd.match(/(\d{1,3})\s*DEG/i);
+            const spdM = emd.match(/(\d{1,3})\s*KT/i);
+            if (!dirM || !spdM) return null;
+            const dirDeg = parseInt(dirM[1], 10);
+            const speedKt = parseInt(spdM[1], 10);
+            // Coordinate pairs are "lat,lon" tokens; grab them all.
+            const points: [number, number][] = [];
+            const re = /(-?\d{1,3}\.\d+)\s*,\s*(-?\d{1,3}\.\d+)/g;
+            let m: RegExpExecArray | null;
+            while ((m = re.exec(emd))) {
+                const lat = parseFloat(m[1]);
+                const lon = parseFloat(m[2]);
+                if (lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180) points.push([lon, lat]);
+            }
+            if (!points.length || !Number.isFinite(dirDeg) || !Number.isFinite(speedKt)) return null;
+            return { dirDeg, speedKt, points };
+        }
+
+        const KT_TO_MPH = 1.151;
+
+        // Build the storm-arrow point features from any alerts carrying motion.
+        function buildStormFeatures(features: any[]) {
+            const out: any[] = [];
+            for (const f of features) {
+                const params = f.properties && f.properties.parameters;
+                const emdArr = params && params.eventMotionDescription;
+                const emd = Array.isArray(emdArr) ? emdArr[0] : emdArr;
+                const motion = parseMotion(emd);
+                if (!motion) continue; // no motion -> polygon only, never fabricate
+                // dirDeg is where the storm comes FROM; heading is where it's GOING.
+                const heading = (motion.dirDeg + 180) % 360;
+                const speedMph = Math.round(motion.speedKt * KT_TO_MPH);
+                for (const pt of motion.points) {
+                    out.push({
+                        type: 'Feature',
+                        geometry: { type: 'Point', coordinates: pt },
+                        properties: {
+                            event: f.properties.event || 'Storm',
+                            dirDeg: motion.dirDeg,
+                            heading,
+                            speedKt: motion.speedKt,
+                            speedMph
+                        }
+                    });
+                }
+            }
+            return { type: 'FeatureCollection', features: out };
         }
 
         async function refreshAlerts() {
-            const btn = document.getElementById('refresh') as HTMLButtonElement;
+            const btn = document.getElementById('refresh') as HTMLButtonElement | null;
             if (btn) btn.disabled = true;
             try {
-                const counts = await Promise.allSettled([fetchAlerts('warnings'), fetchAlerts('hazards')]);
-                const w = counts[0].status === 'fulfilled' ? counts[0].value : 'err';
-                const h = counts[1].status === 'fulfilled' ? counts[1].value : 'err';
-                const failed = counts.find((c) => c.status === 'rejected') as PromiseRejectedResult | undefined;
-                if (w === 0 && h === 0) {
-                    setStatus('No active alerts.');
-                } else {
-                    setStatus(`${w} warning(s), ${h} watch/hazard(s) · updated ${new Date().toLocaleTimeString()}`);
+                // Trailing slash: next.config has trailingSlash:true, so this avoids a 308 redirect hop.
+                const res = await fetch('/api/alerts/?resource=alerts', { headers: { Accept: 'application/geo+json' } });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const geojson = await res.json();
+                const all: any[] = Array.isArray(geojson.features) ? geojson.features : [];
+
+                // Only polygon-bearing alerts go to the fill/line layers.
+                const polys = all.filter((f) => f.geometry);
+                const warnings: any[] = [];
+                const hazards: any[] = [];
+                for (const f of polys) {
+                    const feat = { ...f, properties: normalizeAlertProps(f.properties) };
+                    (isWarning(f.properties.event) ? warnings : hazards).push(feat);
                 }
-                if (failed) {
-                    setStatus(`Alert fetch error: ${failed.reason.message}.`, true);
+
+                const wSrc = map.getSource(ALERT_LAYERS.warnings.sourceId) as any;
+                const hSrc = map.getSource(ALERT_LAYERS.hazards.sourceId) as any;
+                if (wSrc) wSrc.setData({ type: 'FeatureCollection', features: warnings });
+                if (hSrc) hSrc.setData({ type: 'FeatureCollection', features: hazards });
+
+                const storms = buildStormFeatures(all);
+                const sSrc = map.getSource(STORM_SOURCE) as any;
+                if (sSrc) sSrc.setData(storms);
+
+                const arrowNote = storms.features.length ? ` · ${storms.features.length} storm-motion arrow(s)` : '';
+                if (warnings.length === 0 && hazards.length === 0) {
+                    setStatus(`No active alerts.${arrowNote}`);
+                } else {
+                    setStatus(
+                        `${warnings.length} warning(s), ${hazards.length} watch/hazard(s)${arrowNote} · updated ${new Date().toLocaleTimeString()}`
+                    );
                 }
             } catch (e: any) {
                 setStatus(`Alert fetch failed: ${e.message}`, true);
@@ -212,17 +335,17 @@ export default function WeatherMap() {
         // --- popups --------------------------------------------------------------
         const POPUP_FIELDS: [string, string][] = [
             ['event', 'Event'],
-            ['phenom', 'Phenom'],
-            ['sig', 'Significance'],
-            ['wfo', 'Office'],
-            ['msg_type', 'Message'],
+            ['severity', 'Severity'],
+            ['senderName', 'Office'],
+            ['messageType', 'Message'],
             ['onset', 'Onset'],
             ['ends', 'Ends'],
-            ['expiration', 'Expires']
+            ['expires', 'Expires']
         ];
 
         function popupHtml(props: any) {
-            const title = props.prod_type || props.event || 'Alert';
+            const title = props.event || 'Alert';
+            const sub = props.headline ? `<p class="sub">${escapeHtml(String(props.headline))}</p>` : '';
             let rows = '';
             for (const [k, label] of POPUP_FIELDS) {
                 if (props[k] != null && props[k] !== '') {
@@ -232,7 +355,18 @@ export default function WeatherMap() {
             const link = props.url
                 ? `<p><a href="${escapeHtml(props.url)}" target="_blank" rel="noopener">Full text →</a></p>`
                 : '';
-            return `<div class="popup"><h3>${escapeHtml(title)}</h3><table>${rows}</table>${link}</div>`;
+            return `<div class="popup"><h3>${escapeHtml(title)}</h3>${sub}<table>${rows}</table>${link}</div>`;
+        }
+
+        function stormPopupHtml(props: any) {
+            return (
+                `<div class="popup"><h3>${escapeHtml(props.event || 'Storm motion')}</h3>` +
+                `<table>` +
+                `<tr><td class="k">Heading</td><td>${props.heading}° (toward)</td></tr>` +
+                `<tr><td class="k">From</td><td>${props.dirDeg}° (meteorological)</td></tr>` +
+                `<tr><td class="k">Speed</td><td>${props.speedMph} mph (${props.speedKt} kt)</td></tr>` +
+                `</table></div>`
+            );
         }
 
         function escapeHtml(s: string) {
@@ -255,7 +389,7 @@ export default function WeatherMap() {
         }
 
         function addAlertLayers(key: string) {
-            const cfg = WFS_LAYERS[key];
+            const cfg = ALERT_LAYERS[key];
             map.addSource(cfg.sourceId, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
             map.addLayer(
                 {
@@ -278,6 +412,150 @@ export default function WeatherMap() {
                 labelLayerId
             );
             wireAlertLayer(cfg);
+        }
+
+        // --- storm-motion arrows -------------------------------------------------
+        // A north-pointing (0°/up) arrow drawn to a canvas; icon-rotate spins it
+        // clockwise to the storm heading, with icon-rotation-alignment:'map'.
+        function addArrowImage() {
+            if (map.hasImage(STORM_ICON)) return;
+            const size = 48;
+            const c = document.createElement('canvas');
+            c.width = size;
+            c.height = size;
+            const ctx = c.getContext('2d');
+            if (!ctx) return;
+            ctx.translate(size / 2, size / 2);
+            // Arrow polygon pointing up (negative y).
+            const pts: [number, number][] = [
+                [0, -18],
+                [-10, -3],
+                [-4, -3],
+                [-4, 17],
+                [4, 17],
+                [4, -3],
+                [10, -3]
+            ];
+            ctx.beginPath();
+            ctx.moveTo(pts[0][0], pts[0][1]);
+            for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+            ctx.closePath();
+            // White halo for contrast over any polygon/basemap, dark fill on top.
+            ctx.lineJoin = 'round';
+            ctx.lineWidth = 5;
+            ctx.strokeStyle = '#ffffff';
+            ctx.stroke();
+            ctx.fillStyle = '#111111';
+            ctx.fill();
+            const img = ctx.getImageData(0, 0, size, size);
+            map.addImage(STORM_ICON, img, { pixelRatio: 2 });
+        }
+
+        function addStormLayer() {
+            addArrowImage();
+            map.addSource(STORM_SOURCE, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+            map.addLayer({
+                id: STORM_LAYER,
+                type: 'symbol',
+                source: STORM_SOURCE,
+                layout: {
+                    'icon-image': STORM_ICON,
+                    'icon-rotate': ['get', 'heading'],
+                    'icon-rotation-alignment': 'map',
+                    'icon-allow-overlap': true,
+                    'icon-ignore-placement': true,
+                    // Scale by speed: faster storm -> bigger arrow.
+                    'icon-size': ['interpolate', ['linear'], ['get', 'speedKt'], 0, 0.6, 60, 1.5],
+                    'text-field': ['concat', ['to-string', ['get', 'speedMph']], ' mph'],
+                    'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
+                    'text-size': 11,
+                    'text-offset': [0, 1.4],
+                    'text-anchor': 'top',
+                    'text-optional': true,
+                    'text-allow-overlap': false
+                },
+                paint: {
+                    'text-color': '#111111',
+                    'text-halo-color': '#ffffff',
+                    'text-halo-width': 1.4
+                }
+            });
+
+            map.on('click', STORM_LAYER, (e: any) => {
+                if (!e.features.length) return;
+                new maplibregl.Popup({ closeButton: true })
+                    .setLngLat(e.lngLat)
+                    .setHTML(stormPopupHtml(e.features[0].properties))
+                    .addTo(map);
+            });
+            map.on('mouseenter', STORM_LAYER, () => (map.getCanvas().style.cursor = 'pointer'));
+            map.on('mouseleave', STORM_LAYER, () => (map.getCanvas().style.cursor = ''));
+        }
+
+        // --- point forecast panel ------------------------------------------------
+        function showForecastCard() {
+            const card = document.getElementById('forecast');
+            if (card) card.hidden = false;
+        }
+
+        function setForecastBody(html: string) {
+            const body = document.getElementById('forecast-body');
+            if (body) body.innerHTML = html;
+            showForecastCard();
+        }
+
+        async function loadForecast(lat: number, lon: number) {
+            setForecastBody('<p class="fc-loading">Loading forecast…</p>');
+            try {
+                const pRes = await fetch(`/api/alerts/?resource=point&lat=${lat.toFixed(4)}&lon=${lon.toFixed(4)}`);
+                if (!pRes.ok) return setForecastBody('<p class="fc-empty">No forecast for this location.</p>');
+                const pj = await pRes.json();
+                const furl = pj.properties && pj.properties.forecast;
+                if (!furl) return setForecastBody('<p class="fc-empty">No forecast for this location.</p>');
+
+                const fRes = await fetch(`/api/alerts/?resource=forecast&url=${encodeURIComponent(furl)}`);
+                if (!fRes.ok) return setForecastBody('<p class="fc-empty">No forecast for this location.</p>');
+                const fj = await fRes.json();
+                const periods = fj.properties && fj.properties.periods;
+                if (!periods || !periods.length)
+                    return setForecastBody('<p class="fc-empty">No forecast for this location.</p>');
+
+                const p = periods[0];
+                const rl = pj.properties.relativeLocation && pj.properties.relativeLocation.properties;
+                const place = rl && rl.city ? `${rl.city}, ${rl.state}` : `${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+                setForecastBody(
+                    `<div class="fc-place">${escapeHtml(place)}</div>` +
+                        `<div class="fc-temp">${p.temperature}°${escapeHtml(p.temperatureUnit || 'F')}</div>` +
+                        `<div class="fc-period">${escapeHtml(p.name || '')}</div>` +
+                        `<div class="fc-short">${escapeHtml(p.shortForecast || '')}</div>` +
+                        `<div class="fc-wind">Wind: ${escapeHtml(`${p.windSpeed || ''} ${p.windDirection || ''}`.trim())}</div>`
+                );
+            } catch (e: any) {
+                setForecastBody(`<p class="fc-empty">Forecast unavailable: ${escapeHtml(e.message)}</p>`);
+            }
+        }
+
+        function useMyLocation() {
+            const btn = document.getElementById('locate') as HTMLButtonElement | null;
+            if (!('geolocation' in navigator)) {
+                setForecastBody('<p class="fc-empty">Geolocation is not available — tap the map instead.</p>');
+                return;
+            }
+            if (btn) btn.disabled = true;
+            setForecastBody('<p class="fc-loading">Locating…</p>');
+            navigator.geolocation.getCurrentPosition(
+                (pos) => {
+                    if (btn) btn.disabled = false;
+                    const { latitude, longitude } = pos.coords;
+                    map.flyTo({ center: [longitude, latitude], zoom: 9 });
+                    loadForecast(latitude, longitude);
+                },
+                () => {
+                    if (btn) btn.disabled = false;
+                    setForecastBody('<p class="fc-empty">Location permission denied — tap the map to pick a point.</p>');
+                },
+                { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 }
+            );
         }
 
         // --- UI wiring ------------------------------------------------------------
@@ -305,10 +583,23 @@ export default function WeatherMap() {
             if (WMS_LAYERS[key]) {
                 map.setLayoutProperty(WMS_LAYERS[key].layerId, 'visibility', vis);
                 if (key === 'precip') (document.getElementById('precip-legend-block') as HTMLElement).hidden = !on;
-            } else if (WFS_LAYERS[key]) {
-                map.setLayoutProperty(WFS_LAYERS[key].fillId, 'visibility', vis);
-                map.setLayoutProperty(WFS_LAYERS[key].lineId, 'visibility', vis);
+            } else if (ALERT_LAYERS[key]) {
+                map.setLayoutProperty(ALERT_LAYERS[key].fillId, 'visibility', vis);
+                map.setLayoutProperty(ALERT_LAYERS[key].lineId, 'visibility', vis);
+                // Storm arrows ride along with the warnings toggle (motion = warnings).
+                if (key === 'warnings' && map.getLayer(STORM_LAYER)) {
+                    map.setLayoutProperty(STORM_LAYER, 'visibility', vis);
+                }
             }
+        }
+
+        // Narrow-viewport behavior: collapse the panel into a top bar by default.
+        const narrowMq = window.matchMedia('(max-width: 640px)');
+        function setPanelCollapsed(collapsed: boolean) {
+            const panel = document.getElementById('panel');
+            const toggle = document.getElementById('panel-toggle');
+            if (panel) panel.classList.toggle('collapsed', collapsed);
+            if (toggle) toggle.setAttribute('aria-expanded', String(!collapsed));
         }
 
         function wireControls() {
@@ -333,6 +624,30 @@ export default function WeatherMap() {
                 refreshRadar();
                 refreshAlerts();
             });
+
+            (document.getElementById('locate') as HTMLButtonElement).addEventListener('click', useMyLocation);
+
+            // Collapsible panel (matters on narrow screens; harmless on wide).
+            const toggle = document.getElementById('panel-toggle');
+            if (toggle)
+                toggle.addEventListener('click', () => {
+                    const panel = document.getElementById('panel');
+                    setPanelCollapsed(!(panel && panel.classList.contains('collapsed')));
+                });
+
+            // Forecast card close button.
+            const fClose = document.getElementById('forecast-close');
+            if (fClose)
+                fClose.addEventListener('click', () => {
+                    const card = document.getElementById('forecast');
+                    if (card) card.hidden = true;
+                });
+
+            // Default to collapsed on phones; expanded on wide. React to rotation/resize.
+            setPanelCollapsed(narrowMq.matches);
+            const onMq = (ev: MediaQueryListEvent) => setPanelCollapsed(ev.matches);
+            if (narrowMq.addEventListener) narrowMq.addEventListener('change', onMq);
+            else narrowMq.addListener(onMq); // older Safari
         }
 
         // --- boot ----------------------------------------------------------------
@@ -341,6 +656,7 @@ export default function WeatherMap() {
 
             addAlertLayers('warnings');
             addAlertLayers('hazards');
+            addStormLayer();
             addOrRefreshWms('radar');
             addOrRefreshWms('precip');
 
@@ -350,6 +666,9 @@ export default function WeatherMap() {
 
             wireControls();
             refreshAlerts();
+
+            // Tap/click anywhere on the map -> point forecast for that spot.
+            map.on('click', (e: any) => loadForecast(e.lngLat.lat, e.lngLat.lng));
 
             // Alerts change frequently; auto-refresh every 5 minutes.
             refreshIntervalId = setInterval(() => {
@@ -372,57 +691,79 @@ export default function WeatherMap() {
             <div id="map" ref={mapRef}></div>
 
             <div id="panel" className="panel">
-                <h1>Weather Map</h1>
+                <div className="panel-head">
+                    <h1>Weather Map</h1>
+                    <button id="panel-toggle" type="button" className="panel-toggle" aria-expanded="true" aria-label="Toggle controls">
+                        Layers
+                    </button>
+                </div>
 
-                <section className="group">
-                    <label className="toggle">
-                        <input type="checkbox" id="t-radar" defaultChecked />
-                        <span>Radar reflectivity (WMS)</span>
-                    </label>
-                    <label className="toggle">
-                        <input type="checkbox" id="t-precip" />
-                        <span>Precip type (WMS)</span>
-                    </label>
-                    <label className="toggle">
-                        <input type="checkbox" id="t-warnings" defaultChecked />
-                        <span>Warnings (WFS)</span>
-                    </label>
-                    <label className="toggle">
-                        <input type="checkbox" id="t-hazards" defaultChecked />
-                        <span>Watches / hazards (WFS)</span>
-                    </label>
-                </section>
+                <div className="panel-body">
+                    <section className="group">
+                        <label className="toggle">
+                            <input type="checkbox" id="t-radar" defaultChecked />
+                            <span>Radar reflectivity (WMS)</span>
+                        </label>
+                        <label className="toggle">
+                            <input type="checkbox" id="t-precip" />
+                            <span>Precip type (WMS)</span>
+                        </label>
+                        <label className="toggle">
+                            <input type="checkbox" id="t-warnings" defaultChecked />
+                            <span>Warnings + storm motion</span>
+                        </label>
+                        <label className="toggle">
+                            <input type="checkbox" id="t-hazards" defaultChecked />
+                            <span>Watches / hazards</span>
+                        </label>
+                    </section>
 
-                <section className="group">
-                    <label className="slider">
-                        Radar opacity
-                        <input type="range" id="radar-opacity" min="0" max="1" step="0.05" defaultValue="0.7" />
-                    </label>
-                    <button id="refresh">↻ Refresh alerts &amp; radar</button>
-                    <div id="status" className="status">
-                        Loading…
-                    </div>
-                </section>
+                    <section className="group">
+                        <label className="slider">
+                            Radar opacity
+                            <input type="range" id="radar-opacity" min="0" max="1" step="0.05" defaultValue="0.7" />
+                        </label>
+                        <button id="locate" type="button">📍 Use my location</button>
+                        <button id="refresh" type="button">↻ Refresh alerts &amp; radar</button>
+                        <div id="status" className="status">
+                            Loading…
+                        </div>
+                    </section>
 
-                <section className="group legend">
-                    <h2>Legend</h2>
-                    <div className="legend-block">
-                        <div className="legend-title">Radar reflectivity</div>
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img id="radar-legend" alt="radar legend" />
-                    </div>
-                    <div className="legend-block" id="precip-legend-block" hidden>
-                        <div className="legend-title">Precip type</div>
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img id="precip-legend" alt="precip type legend" />
-                    </div>
-                    <div className="legend-block">
-                        <div className="legend-title">Alerts (by hazard)</div>
-                        <ul id="alert-legend" className="alert-legend"></ul>
-                    </div>
-                </section>
+                    <section className="group legend">
+                        <h2>Legend</h2>
+                        <div className="legend-block">
+                            <div className="legend-title">Radar reflectivity</div>
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img id="radar-legend" alt="radar legend" />
+                        </div>
+                        <div className="legend-block" id="precip-legend-block" hidden>
+                            <div className="legend-title">Precip type</div>
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img id="precip-legend" alt="precip type legend" />
+                        </div>
+                        <div className="legend-block">
+                            <div className="legend-title">Alerts (by hazard)</div>
+                            <ul id="alert-legend" className="alert-legend"></ul>
+                        </div>
+                        <div className="legend-block">
+                            <div className="legend-title">Storm motion</div>
+                            <div className="motion-note">Arrows point where the storm is heading; label = speed (mph).</div>
+                        </div>
+                    </section>
 
-                <footer>Data: NOAA/NWS nowCOAST &amp; api.weather.gov · Not for operational use</footer>
+                    <footer>Data: NOAA/NWS nowCOAST &amp; api.weather.gov · Not for operational use · Tap the map for a point forecast</footer>
+                </div>
+            </div>
+
+            <div id="forecast" className="forecast" hidden>
+                <div className="forecast-head">
+                    <span className="forecast-title">Point forecast</span>
+                    <button id="forecast-close" type="button" className="forecast-close" aria-label="Close forecast">
+                        ✕
+                    </button>
+                </div>
+                <div id="forecast-body" className="forecast-body"></div>
             </div>
         </div>
     );

--- a/src/pages/api/alerts.js
+++ b/src/pages/api/alerts.js
@@ -38,8 +38,14 @@ function resolveUpstream(qp) {
   const resource = qp.resource || 'alerts';
 
   if (resource === 'alerts') {
-    // All active alerts; each feature carries geometry (polygon) and, for
-    // convective products, parameters.eventMotionDescription.
+    // Active alerts; each feature carries geometry (polygon) and, for convective
+    // products, parameters.eventMotionDescription. Optional `area` bounds the
+    // result to a set of state/territory codes (the map sends the states in view)
+    // so we don't pull the whole national feed. Validated to plain 2-letter codes.
+    const area = String(qp.area || '').toUpperCase();
+    if (area && /^[A-Z]{2}(,[A-Z]{2})*$/.test(area)) {
+      return `${BASE}/alerts/active?area=${encodeURIComponent(area)}`;
+    }
     return `${BASE}/alerts/active`;
   }
 

--- a/src/pages/api/alerts.js
+++ b/src/pages/api/alerts.js
@@ -1,0 +1,116 @@
+/* Next.js API route: api.weather.gov proxy.
+ *
+ * api.weather.gov *sends* permissive CORS headers, so a browser could call it
+ * directly — except it rejects every request that lacks a descriptive
+ * `User-Agent`, and browsers will not let JS set that header. So we proxy
+ * server-side: the UA is always attached here, and we add CORS + a short cache.
+ *
+ * Three resources, all SSRF-safe (upstream host + path are allow-listed — this
+ * is never an open proxy):
+ *   GET /api/alerts?resource=alerts               -> /alerts/active (GeoJSON: polygons + storm motion)
+ *   GET /api/alerts?resource=point&lat=..&lon=..  -> /points/{lat},{lon} (forecast URL discovery)
+ *   GET /api/alerts?resource=forecast&url=<url>   -> a /gridpoints/.../forecast URL from the point response
+ *
+ * Uses the global `fetch` (Node 18+).
+ */
+
+const BASE = 'https://api.weather.gov';
+// Descriptive UA is mandatory; api.weather.gov 403s requests without one.
+const USER_AGENT = 'boblemieux.ai weather map, contact roblem28@gmail.com';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+function applyCors(res) {
+  for (const [k, v] of Object.entries(CORS)) res.setHeader(k, v);
+}
+
+function finiteNum(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Resolve the validated upstream URL for a request, or throw a 400-worthy Error.
+function resolveUpstream(qp) {
+  const resource = qp.resource || 'alerts';
+
+  if (resource === 'alerts') {
+    // All active alerts; each feature carries geometry (polygon) and, for
+    // convective products, parameters.eventMotionDescription.
+    return `${BASE}/alerts/active`;
+  }
+
+  if (resource === 'point') {
+    const lat = finiteNum(qp.lat);
+    const lon = finiteNum(qp.lon);
+    if (lat === null || lon === null || lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+      const e = new Error('Invalid or missing lat/lon');
+      e.code = 400;
+      throw e;
+    }
+    // api.weather.gov rejects coordinates with more than 4 decimals.
+    return `${BASE}/points/${lat.toFixed(4)},${lon.toFixed(4)}`;
+  }
+
+  if (resource === 'forecast') {
+    const raw = qp.url || '';
+    let u;
+    try {
+      u = new URL(raw);
+    } catch {
+      const e = new Error('Invalid forecast url');
+      e.code = 400;
+      throw e;
+    }
+    // SSRF guard: only api.weather.gov gridpoint forecast URLs (as returned by the point lookup).
+    const okHost = u.protocol === 'https:' && u.host === 'api.weather.gov';
+    const okPath = u.pathname.startsWith('/gridpoints/') && /\/forecast(\/hourly)?$/.test(u.pathname);
+    if (!okHost || !okPath) {
+      const e = new Error('Forecast url not allowed');
+      e.code = 400;
+      throw e;
+    }
+    return u.toString();
+  }
+
+  const e = new Error("Unknown 'resource'");
+  e.code = 400;
+  throw e;
+}
+
+export default async function handler(req, res) {
+  applyCors(res);
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end();
+  }
+
+  let upstream;
+  try {
+    upstream = resolveUpstream(req.query || {});
+  } catch (err) {
+    res.setHeader('Content-Type', 'application/json');
+    return res.status(err.code || 400).json({ error: err.message, allowed: ['alerts', 'point', 'forecast'] });
+  }
+
+  try {
+    const r = await fetch(upstream, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        // geo+json keeps real GeoJSON geometry (needed to draw polygons on the map).
+        Accept: 'application/geo+json'
+      }
+    });
+    const body = await r.text();
+    res.setHeader('Content-Type', r.headers.get('content-type') || 'application/json');
+    // Short cache: alerts/forecasts update on the order of minutes, not seconds.
+    res.setHeader('Cache-Control', 'public, max-age=60');
+    return res.status(r.status).send(body);
+  } catch (err) {
+    res.setHeader('Content-Type', 'application/json');
+    return res.status(502).json({ error: 'Upstream api.weather.gov fetch failed', detail: String(err) });
+  }
+}

--- a/src/pages/projects/weather.tsx
+++ b/src/pages/projects/weather.tsx
@@ -16,7 +16,7 @@ export default function WeatherPage(props: any) {
                     name="description"
                     content="Live NOAA/NWS radar, precip type, and severe-weather alerts on an interactive MapLibre map."
                 />
-                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
             </Head>
             <BaseLayout {...props}>
                 <div className="px-4 py-8">


### PR DESCRIPTION
## Summary

Three additive features on the `WeatherMap` client component, plus one new API proxy route. **The spending app, global CSS, and the catch-all router are untouched.** `src/pages/api/wfs.js` is left in place but is now unused by the map (alerts moved to api.weather.gov).

### 1. Storm-motion arrows
- Alerts now come from **api.weather.gov** `/alerts/active` instead of the NCEP WFS. api.weather.gov requires a descriptive `User-Agent` header that browsers won't let JS set, so requests go through a **new server-side proxy `/api/alerts`** (attaches the UA, adds CORS + a 60s cache, SSRF-safe via host + path allow-listing). This was the recommended approach over calling api.weather.gov directly.
- Parses `parameters.eventMotionDescription` with a tolerant regex (handles the extra `storm` token and multi-point storm lines).
- **Convention:** `dirDeg` is the direction the storm moves *from*, so the drawn heading is `(dirDeg + 180) % 360`. Arrow is a north-pointing MapLibre symbol icon, rotated to heading (`icon-rotation-alignment: map`), scaled by speed, labelled in mph (`kt * 1.151`).
- Only alerts that actually carry motion get arrows; everything else renders as polygons exactly as before. The two existing warnings/hazards toggles still work.

### 2. Point forecast panel
- Tap the map (or **"Use my location"** via `navigator.geolocation`) → `/points/{lat,lon}` → forecast URL → current period (temp °F, short forecast, wind) in a small card.
- Ocean / no-grid points and errors show **"No forecast for this location."** Permission-denied falls back to map-tap.

### 3. Mobile-responsive + touch + iOS
- Capability-based `@media (max-width: 640px)` + `matchMedia` (no UA sniffing). Phone layout collapses controls into a top bar with a full-bleed map; wide keeps the side panel.
- **`100dvh`** (not `100vh`) + **`viewport-fit=cover`** + `safe-area-inset` so the map doesn't overflow under the iOS address bar / notch / home bar. The `viewport-fit` change is scoped to the weather page's own viewport meta.
- ≥44px tap targets; popups/forecast open on tap; native pinch/pan left intact.

## Validation
- `npm run build` succeeds; `/projects/weather` + `/api/alerts` build; spending and all other routes unchanged.
- Proxy verified live: land point returns a forecast; ocean point → upstream 500 → "No forecast"; SSRF guard rejects non-api.weather.gov forecast URLs (400).
- **Heading math, live convective examples:**
  - `Severe Thunderstorm Warning` — `...047DEG...12KT...34.67,-83.41` → FROM 47°, heading **227°**, 14 mph
  - `Severe Thunderstorm Warning` — `...259DEG...35KT...` (3-point line) → FROM 259°, heading **79°**, 40 mph
  - `Severe Thunderstorm Warning` — `...011DEG...14KT...33.53,-82.9` → FROM 11°, heading **191°**, 16 mph
- Browser-driven visual checks (390px/768px/desktop reflow, live arrow render) were **not** run here — the Chrome extension wasn't connected in this environment. Please review the Deploy Preview on a phone as planned.

## Notes
- Existing radar/precip WMS layers, opacity slider, refresh, and polygon toggles are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
